### PR TITLE
Fix executable, update README, update messages, update modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,25 +18,28 @@ places in the code.
 
 Install by using `go get -u github.com/bombsimon/wsl`.
 
-By default, the linter will lint current directory **non** recursive. To specify
-a file or directory, pass it as argument to the linter. To follow directories
-recursive, use `--recursive`.
+Run with `wsl [--no-test] <file1> [files...]` or `wsl ./package/...`. The "..." wildcard is
+not used like other `go` commands but instead can only be to a relative or
+absolute path.
 
-Example:
+By default, the linter will run on `./...` which means all go files in the
+current path and all subsequent paths, including test files. To disable linting
+test files, use `-n` or `--no-test`.
+
+Example (assuming globstar is enabled):
 
 ```
-wsl --recursive $GOPATH/src/github.com/bombsimon/wsl/*/0*
+wsl $GOPATH/src/github.com/bombsimon/wsl/**/0*
 testfiles/01.go:10: block should not start with a whitespace
 testfiles/01.go:17: if statements can only be cuddled with assigments
 testfiles/01.go:24: assigments can only be cuddled with other assigments
 testfiles/01.go:34: block should not start with a whitespace
-testfiles/01.go:36: block should not end with a whitespace
+testfiles/01.go:36: block should not end with a whitespace (or comment)
 testfiles/01.go:41: if statements can only be cuddled with assigments used in the if statement itself
-testfiles/01.go:54: block should not end with a whitespace
+testfiles/01.go:54: block should not end with a whitespace (or comment)
 testfiles/01_test.go:5: block should not start with a whitespace
-testfiles/01_test.go:7: block should not end with a whitespace
+testfiles/01_test.go:7: block should not end with a whitespace (or comment)
 testfiles/03.go:9: declarations can never be cuddled
 testfiles/recursive/01.go:5: block should not start with a whitespace
-testfiles/recursive/01.go:7: block should not end with a whitespace
-exit status 2
+testfiles/recursive/01.go:7: block should not end with a whitespace (or comment)
 ```

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,5 @@
 module github.com/bombsimon/wsl
 
-require (
-	github.com/bombsimon/ff v0.0.0-20181002164615-37c9448350e2
-	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/stretchr/testify v1.2.2
-)
+go 1.12
+
+require github.com/stretchr/testify v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,7 @@
-github.com/bombsimon/ff v0.0.0-20181002164615-37c9448350e2 h1:4GQ9fxp4wRfLDVCLeEMRPz6tGo0kP2dDI1p7tsmUYs0=
-github.com/bombsimon/ff v0.0.0-20181002164615-37c9448350e2/go.mod h1:0KHNnAIrVeP6XDXegqMsf3WsZZw+xhd8SFLYzEyd6Ag=
-github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
-github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
-github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=

--- a/wsl.go
+++ b/wsl.go
@@ -170,7 +170,13 @@ func parseBlockStatements(fset *token.FileSet, comments []*ast.CommentGroup, sta
 						expressionInIfStatement = expressionType
 					case *ast.CallExpr:
 						// TODO: Recursive check args to function X and/or Y
-						continue
+						// In the meantime, handle one X expression (Lfs) and
+						// ignore Y expression (Rhs)
+						if len(expressionType.Args) == 1 {
+							if v, ok := expressionType.Args[0].(*ast.Ident); ok {
+								expressionInIfStatement = v
+							}
+						}
 					}
 				case *ast.UnaryExpr:
 					expressionInIfStatement = x.X.(*ast.Ident)


### PR DESCRIPTION
* Executable accepts multiple files, leave logic to shell.
* Executable accepts "..." wildcard-ish syntax (like ./pkg/...)
* Support for --no-test (-n) to ignore test files
* Update README with correct information
* Handle one (of many) if-CallExpr cases