### PR TITLE
Allow multiline assignments to be cuddled. Support config flags

### DIFF
--- a/cmd/wsl/main.go
+++ b/cmd/wsl/main.go
@@ -19,6 +19,7 @@ func main() {
 		cwd, _       = os.Getwd()
 		files        = []string{}
 		finalFiles   = []string{}
+		config       = wsl.DefaultConfig()
 	)
 
 	flag.BoolVar(&help, "h", false, "Show this help text")
@@ -27,6 +28,10 @@ func main() {
 	flag.BoolVar(&noTest, "no-test", false, "")
 	flag.BoolVar(&showWarnings, "w", false, "Show warnings (ignored rules)")
 	flag.BoolVar(&showWarnings, "warnings", false, "")
+
+	flag.BoolVar(&config.CheckAppend, "check-append", true, "Strict rules for append")
+	flag.BoolVar(&config.AllowAssignAndCallsCuddle, "allow-assign-and-call", true, "Allow assignments and calls to be cuddled (if using same variable/type)")
+	flag.BoolVar(&config.AllowMultiLineAssignmentCuddled, "allow-multi-line-assignment", true, "Allow cuddling with multi line assignments")
 
 	flag.Parse()
 
@@ -71,7 +76,7 @@ func main() {
 		finalFiles = append(finalFiles, f)
 	}
 
-	processor := wsl.NewProcessor()
+	processor := wsl.NewProcessorWithConfig(config)
 	result, warnings := processor.ProcessFiles(finalFiles)
 
 	for _, r := range result {

--- a/wsl_test.go
+++ b/wsl_test.go
@@ -408,23 +408,6 @@ func TestShouldAddEmptyLines(t *testing.T) {
 			}`),
 		},
 		{
-			description: "multi line assignment should not be seen as assignment above",
-			code: []byte(`package main
-
-			func main() {
-				// This should not be OK since the assignment is split at
-				// multiple rows.
-				err := SomeFunc(
-					"taking multiple values",
-					"suddendly not a single line",
-				)
-				if err != nil {
-					fmt.Println("denied")
-				}
-			}`),
-			expectedErrorStrings: []string{"if statements should only be cuddled with assignments"},
-		},
-		{
 			description: "allow cuddle for immediate assignment in block",
 			code: []byte(`package main
 
@@ -1020,6 +1003,55 @@ func TestWithConfig(t *testing.T) {
 			customConfig: &Configuration{
 				AllowAssignAndCallsCuddle: true,
 			},
+		},
+		{
+			description: "multi line assignment ok when enabled",
+			code: []byte(`package main
+
+			func main() {
+				// This should not be OK since the assignment is split at
+				// multiple rows.
+				err := SomeFunc(
+					"taking multiple values",
+					"suddendly not a single line",
+				)
+				if err != nil {
+					fmt.Println("denied")
+				}
+			}`),
+			customConfig: &Configuration{
+				AllowMultiLineAssignmentCuddled: false,
+			},
+			expectedErrorStrings: []string{"if statements should only be cuddled with assignments"},
+		},
+		{
+			description: "multi line assignment not ok when disabled",
+			code: []byte(`package main
+
+			func main() {
+				// This should not be OK since the assignment is split at
+				// multiple rows.
+				err := SomeFunc(
+					"taking multiple values",
+					"suddenly not a single line",
+				)
+				if err != nil {
+					fmt.Println("accepted")
+				}
+
+				// This should still fail since it's not the same variable
+				noErr := SomeFunc(
+					"taking multiple values",
+					"suddenly not a single line",
+				)
+				if err != nil {
+					fmt.Println("rejected")
+				}
+			}`),
+			customConfig: &Configuration{
+				AllowMultiLineAssignmentCuddled: true,
+			},
+			expectedErrorStrings: []string{"if statements should only be cuddled with assignments used in the if statement itself"},
 		},
 	}
 


### PR DESCRIPTION
Resolves #22 