### PR TITLE
Option to allow cuddle declarations

### DIFF
--- a/cmd/wsl/main.go
+++ b/cmd/wsl/main.go
@@ -34,6 +34,7 @@ func main() {
 	flag.BoolVar(&config.AllowAssignAndCallCuddle, "allow-assign-and-call", true, "Allow assignments and calls to be cuddled (if using same variable/type)")
 	flag.BoolVar(&config.AllowMultiLineAssignCuddle, "allow-multi-line-assign", true, "Allow cuddling with multi line assignments")
 	flag.BoolVar(&config.AllowCaseTrailingWhitespace, "allow-case-trailing-whitespace", false, "Allow case statements to end with an empty line")
+	flag.BoolVar(&config.AllowCuddleDeclaration, "allow-declarations", false, "Allow declarations to be cuddled")
 
 	flag.Parse()
 

--- a/wsl.go
+++ b/wsl.go
@@ -65,6 +65,13 @@ type Configuration struct {
 	// }
 	AllowCaseTrailingWhitespace bool
 
+	// AllowCuddleDeclaration will allow multiple var/declaration statements to
+	// be cuddled. This defaults to false but setting it to true will enable the
+	// following example:
+	//  var foo bool
+	//  var err error
+	AllowCuddleDeclaration bool
+
 	// AllowCuddleWithCalls is a list of call idents that everything can be
 	// cuddled with. Defaults to calls looking like locks to support a flow like
 	// this:
@@ -362,7 +369,9 @@ func (p *Processor) parseBlockStatements(statements []ast.Stmt) {
 
 			p.addError(t.Pos(), "assignments should only be cuddled with other assignments")
 		case *ast.DeclStmt:
-			p.addError(t.Pos(), "declarations should never be cuddled")
+			if !p.config.AllowCuddleDeclaration {
+				p.addError(t.Pos(), "declarations should never be cuddled")
+			}
 		case *ast.ExprStmt:
 			switch previousStatement.(type) {
 			case *ast.DeclStmt, *ast.ReturnStmt:

--- a/wsl_test.go
+++ b/wsl_test.go
@@ -1188,6 +1188,23 @@ func TestWithConfig(t *testing.T) {
 				AllowCaseTrailingWhitespace: true,
 			},
 		},
+		{
+			description: "allow cuddle var",
+			code: []byte(`package main
+
+			func main() {
+				var t bool
+				var err error
+
+				var t = true
+				if t {
+					fmt.Println("x")
+				}
+			}`),
+			customConfig: &Configuration{
+				AllowCuddleDeclaration: true,
+			},
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
Option to allow multiple declarations (`var`). Example:

```go
func main() {
    var t bool
    var err error

    var t = true
    if t {
        fmt.Println("x")
    }
}
```

This resolves #32 