### PR TITLE
Support cuddle http body close with error check

### DIFF
--- a/wsl_test.go
+++ b/wsl_test.go
@@ -1055,6 +1055,18 @@ func TestShouldAddEmptyLines(t *testing.T) {
 				"block should not end with a whitespace (or comment)",
 			},
 		},
+		{
+			description: "allow http body close best practice",
+			code: []byte(`package main
+
+			func main() {
+				resp, err := client.Do(req)
+				if err != nil {
+					return err
+				}
+				defer resp.Body.Close()
+			}`),
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
This resolves #31 

The implementation is **very** specific to this use case but I imagine this is the only way not already allowed which should be supported. If there are more cases needed to handle this we can add them later!