### PR TITLE
Add configuration and support to end blocks with comments

### DIFF
--- a/cmd/wsl/main.go
+++ b/cmd/wsl/main.go
@@ -34,7 +34,8 @@ func main() {
 	flag.BoolVar(&config.AllowAssignAndCallCuddle, "allow-assign-and-call", true, "Allow assignments and calls to be cuddled (if using same variable/type)")
 	flag.BoolVar(&config.AllowMultiLineAssignCuddle, "allow-multi-line-assign", true, "Allow cuddling with multi line assignments")
 	flag.BoolVar(&config.AllowCaseTrailingWhitespace, "allow-case-trailing-whitespace", false, "Allow case statements to end with an empty line")
-	flag.BoolVar(&config.AllowCuddleDeclaration, "allow-declarations", false, "Allow declarations to be cuddled")
+	flag.BoolVar(&config.AllowCuddleDeclaration, "allow-cuddle-declarations", false, "Allow declarations to be cuddled")
+	flag.BoolVar(&config.AllowTrailingComment, "allow-trailing-comment", false, "Allow blocks to end with a comment")
 
 	flag.Parse()
 

--- a/wsl_test.go
+++ b/wsl_test.go
@@ -1232,6 +1232,65 @@ func TestWithConfig(t *testing.T) {
 				AllowCuddleDeclaration: true,
 			},
 		},
+		{
+			description: "support to end blocks with a comment",
+			code: []byte(`package main
+
+			func main() {
+				for i := range make([]int, 10) {
+					fmt.Println("x")
+					// This is OK
+				}
+
+				for i := range make([]int, 10) {
+					fmt.Println("x")
+					// Pad
+					// With empty lines
+					//
+					// This is OK
+				}
+
+				for i := range make([]int, 10) {
+					fmt.Println("x")
+
+					// This is NOT OK
+				}
+
+				for i := range make([]int, 10) {
+					fmt.Println("x")
+					// This is NOT OK
+
+				}
+
+				for i := range make([]int, 10) {
+					fmt.Println("x")
+					/* Block comment one line OK */
+				}
+
+				for i := range make([]int, 10) {
+					fmt.Println("x")
+					/*
+						Block comment one multiple lines OK
+					*/
+				}
+
+				switch {
+				case true:
+					fmt.Println("x")
+					// This is OK
+				case false:
+					fmt.Println("y")
+					// This is OK
+				}
+			}`),
+			customConfig: &Configuration{
+				AllowTrailingComment: true,
+			},
+			expectedErrorStrings: []string{
+				"block should not end with a whitespace (or comment)",
+				"block should not end with a whitespace (or comment)",
+			},
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
Resolves #43 

Flag is `--allow-traling-comment` and will allow comments in all forms as long as there's no empty line between the lats statement and the left brace.

**Ok**

```go
if true {
    fmt.Println("x")
    // Comment
}

if true {
    fmt.Println("x")
    // Comment
    //
    // Comment
}

if true {
    fmt.Println("x")
    /* Comment */
}

if true {
    fmt.Println("x")
    /*
        Multiline
    */
}
```

**Not ok**

```go
if true {
    fmt.Println("x")

    // Comment
}

if true {
    fmt.Println("x")
    // Comment

}
```