### PR TITLE
Support multiple go statements, fix IncDec bug

### DIFF
--- a/wsl.go
+++ b/wsl.go
@@ -603,9 +603,10 @@ func (p *Processor) findLHS(node ast.Node) []string {
 		*ast.ReturnStmt, *ast.GoStmt, *ast.CaseClause,
 		*ast.CommClause, *ast.CallExpr, *ast.UnaryExpr,
 		*ast.BranchStmt, *ast.TypeSpec, *ast.ChanType,
-		*ast.DeferStmt, *ast.TypeAssertExpr, *ast.IncDecStmt,
-		*ast.RangeStmt:
-		// Nothing to add to LHS
+		*ast.DeferStmt, *ast.TypeAssertExpr, *ast.RangeStmt:
+	// Nothing to add to LHS
+	case *ast.IncDecStmt:
+		return p.findLHS(t.X)
 	case *ast.Ident:
 		return []string{t.Name}
 	case *ast.AssignStmt:

--- a/wsl.go
+++ b/wsl.go
@@ -477,6 +477,10 @@ func (p *Processor) parseBlockStatements(statements []ast.Stmt) {
 				}
 			}
 		case *ast.GoStmt:
+			if _, ok := previousStatement.(*ast.GoStmt); ok {
+				continue
+			}
+
 			if moreThanOneStatementAbove() {
 				p.addError(t.Pos(), "only one cuddle assignment allowed before go statement")
 

--- a/wsl_test.go
+++ b/wsl_test.go
@@ -1113,6 +1113,30 @@ func TestShouldAddEmptyLines(t *testing.T) {
 				"only one cuddle assignment allowed before go statement",
 			},
 		},
+		{
+			description: "boilerplate",
+			code: []byte(`package main
+
+			func main() {
+				counter := 0
+				if somethingTrue {
+					counter++
+				}
+
+				counterTwo := 0
+				if somethingTrue {
+					counterTwo--
+				}
+
+				notCounter := 0
+				if somethingTrue {
+					counter--
+				}
+			}`),
+			expectedErrorStrings: []string{
+				"if statements should only be cuddled with assignments used in the if statement itself",
+			},
+		},
 	}
 
 	for _, tc := range cases {

--- a/wsl_test.go
+++ b/wsl_test.go
@@ -1082,6 +1082,37 @@ func TestShouldAddEmptyLines(t *testing.T) {
 				defer resp.Body.Close()
 			}`),
 		},
+		{
+			description: "multiple go statements can be cuddled",
+			code: []byte(`package main
+
+			func main() {
+				t1 := NewT()
+				t2 := NewT()
+				t3 := NewT()
+
+				go t1()
+				go t2()
+				go t3()
+
+				multiCuddle1 := NewT()
+				multiCuddle2 := NewT()
+				go multiCuddle2()
+
+				multiCuddle3 := NeT()
+				go multiCuddle1()
+
+				t4 := NewT()
+				t5 := NewT()
+				go t5()
+				go t4()
+			}`),
+			expectedErrorStrings: []string{
+				"only one cuddle assignment allowed before go statement",
+				"go statements can only invoke functions assigned on line above",
+				"only one cuddle assignment allowed before go statement",
+			},
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
Resolves #42, now supports:

```go
go func1()
go func2()
go func3()
```

Also fixes an unreported bug where variables used as increase or decrease statement wasn't considered. This was not, but is now, supported:

```go
counter := 0
if [expr] {
    counter++
}
```