### PR TITLE
Support to force/forbid ending newlines in case block

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ feel free to raise an [issue](https://github.com/bombsimon/wsl/issues/new).
 * [Assignments should only be cuddled with other assignments](doc/rules.md#assignments-should-only-be-cuddled-with-other-assignments)
 * [Block should not end with a whitespace (or comment)](doc/rules.md#block-should-not-end-with-a-whitespace-or-comment)
 * [Block should not start with a whitespace](doc/rules.md#block-should-not-start-with-a-whitespace)
+* [Case block should end with newline at this size](doc/rules.md#case-block-should-end-with-newline-at-this-size)
 * [Branch statements should not be cuddled if block has more than two lines](doc/rules.md#branch-statements-should-not-be-cuddled-if-block-has-more-than-two-lines)
 * [Declarations should never be cuddled](doc/rules.md#declarations-should-never-be-cuddled)
 * [Defer statements should only be cuddled with expressions on same variable](doc/rules.md#defer-statements-should-only-be-cuddled-with-expressions-on-same-variable)

--- a/cmd/wsl/main.go
+++ b/cmd/wsl/main.go
@@ -33,9 +33,15 @@ func main() {
 	flag.BoolVar(&config.StrictAppend, "strict-append", true, "Strict rules for append")
 	flag.BoolVar(&config.AllowAssignAndCallCuddle, "allow-assign-and-call", true, "Allow assignments and calls to be cuddled (if using same variable/type)")
 	flag.BoolVar(&config.AllowMultiLineAssignCuddle, "allow-multi-line-assign", true, "Allow cuddling with multi line assignments")
-	flag.BoolVar(&config.AllowCaseTrailingWhitespace, "allow-case-trailing-whitespace", false, "Allow case statements to end with an empty line")
 	flag.BoolVar(&config.AllowCuddleDeclaration, "allow-cuddle-declarations", false, "Allow declarations to be cuddled")
 	flag.BoolVar(&config.AllowTrailingComment, "allow-trailing-comment", false, "Allow blocks to end with a comment")
+
+	flag.IntVar(
+		&config.CaseForceTrailingWhitespaceLimit,
+		"force-case-trailing-whitespace",
+		0,
+		"Force newlines for case blocks > this number. 0 will never force (but always allow). 1 will always force. 99999 will (hopefully) alway forbid.",
+	)
 
 	flag.Parse()
 

--- a/cmd/wsl/main.go
+++ b/cmd/wsl/main.go
@@ -35,13 +35,7 @@ func main() {
 	flag.BoolVar(&config.AllowMultiLineAssignCuddle, "allow-multi-line-assign", true, "Allow cuddling with multi line assignments")
 	flag.BoolVar(&config.AllowCuddleDeclaration, "allow-cuddle-declarations", false, "Allow declarations to be cuddled")
 	flag.BoolVar(&config.AllowTrailingComment, "allow-trailing-comment", false, "Allow blocks to end with a comment")
-
-	flag.IntVar(
-		&config.CaseForceTrailingWhitespaceLimit,
-		"force-case-trailing-whitespace",
-		0,
-		"Force newlines for case blocks > this number. 0 will never force (but always allow). 1 will always force. 99999 will (hopefully) alway forbid.",
-	)
+	flag.IntVar(&config.CaseForceTrailingWhitespaceLimit, "force-case-trailing-whitespace", 0, "Force newlines for case blocks > this number.")
 
 	flag.Parse()
 

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -71,33 +71,57 @@ x = AssignAgain()
 x.CallAgain()
 ```
 
-### [allow-multiline-assign](rules.md#only-cuddled-expressions-if-assigning-variable-or-using-from-line-above)
+### [force-case-trailing-whitespace](rules.md#case-block-should-(never)-end-with-newline-at-this-size)
 
-Controls if you may cuddle assignments even if they span over multiple lines.
+If you **always** want to end a case block with a newline, this should be
+set to 1. If you **never** want to allow a block to end with a newline, this
+could be set to a large number (9999). If you want to be able to mix and match
+and set this to whatever suits the person the best, set this to 0.
 
-> Default value: true
+This can be combined with
+[allow-trailing-comment](configuration.md#allow-trailing-comment) so that a
+block must have a newline after the comment.
 
-Supported when true:
+> Default value: 0 (allow both)
+
+Supported when set to 0:
 
 ```go
-assignment := fmt.Sprintf(
-    "%s%s",
-    "I span over", "multiple lines"
-)
-assignmentTwo := "and yet I may be cuddled"
-assignmentThree := "this is fine"
+switch n {
+case 1:
+    fmt.Println("newline")
+
+case 2:
+    fmt.Println("no newline")
+case 3:
+    fmt.Println("Many")
+    fmt.Println("lines")
+    fmt.Println("without")
+    fmt.Println("newlinew")
+case 4:
+    fmt.Println("done"9)
+}
 ```
 
-Required when false:
+Required when set to 1:
 
 ```go
-assignment := fmt.Sprintf(
-    "%s%s",
-    "I span over", "multiple lines"
-)
+switch n {
+case 1:
+    fmt.Println("newline")
 
-assignmentTwo := "so I cannot be cuddled"
-assignmentThree := "this is fine"
+case 2:
+    fmt.Println("also newline")
+
+case 3:
+    fmt.Println("Many")
+    fmt.Println("lines")
+    fmt.Println("WITH")
+    fmt.Println("newline")
+
+case 4:
+    fmt.Println("done"9)
+}
 ```
 
 ### [allow-cuddle-declarations](rules.md#declarations-should-never-be-cuddled)

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -71,18 +71,43 @@ x = AssignAgain()
 x.CallAgain()
 ```
 
-### [force-case-trailing-whitespace](rules.md#case-block-should-(never)-end-with-newline-at-this-size)
+### [allow-multiline-assign](rules.md#only-cuddled-expressions-if-assigning-variable-or-using-from-line-above)
 
-If you **always** want to end a case block with a newline, this should be
-set to 1. If you **never** want to allow a block to end with a newline, this
-could be set to a large number (9999). If you want to be able to mix and match
-and set this to whatever suits the person the best, set this to 0.
+Controls if you may cuddle assignments even if they span over multiple lines.
 
-This can be combined with
-[allow-trailing-comment](configuration.md#allow-trailing-comment) so that a
-block must have a newline after the comment.
+> Default value: true
 
-> Default value: 0 (allow both)
+Supported when true:
+
+```go
+assignment := fmt.Sprintf(
+    "%s%s",
+    "I span over", "multiple lines"
+)
+assignmentTwo := "and yet I may be cuddled"
+assignmentThree := "this is fine"
+```
+
+Required when false:
+
+```go
+assignment := fmt.Sprintf(
+    "%s%s",
+    "I span over", "multiple lines"
+)
+
+assignmentTwo := "so I cannot be cuddled"
+assignmentThree := "this is fine"
+```
+
+### [force-case-trailing-whitespace](rules.md#case-block-should-end-with-newline-at-this-size)
+
+Can be set to force trailing newlines at the end of case blocks to improve
+readability. If the number of lines (including comments) in a case block exceeds
+this number a linter error will be yielded if the case does not end with a
+newline.
+
+> Default value: 0 (never force)
 
 Supported when set to 0:
 
@@ -99,26 +124,23 @@ case 3:
     fmt.Println("without")
     fmt.Println("newlinew")
 case 4:
-    fmt.Println("done"9)
+    fmt.Println("done")
 }
 ```
 
-Required when set to 1:
+Required when set to 2:
 
 ```go
 switch n {
 case 1:
-    fmt.Println("newline")
+    fmt.Println("must have")
+    fmt.Println("empty whitespace")
 
 case 2:
-    fmt.Println("also newline")
+    fmt.Println("might have empty whitespace")
 
 case 3:
-    fmt.Println("Many")
-    fmt.Println("lines")
-    fmt.Println("WITH")
-    fmt.Println("newline")
-
+    fmt.Println("might skip empty whitespace")
 case 4:
     fmt.Println("done"9)
 }

--- a/doc/rules.md
+++ b/doc/rules.md
@@ -114,8 +114,7 @@ fmt.Println("x")
 ### Block should not end with a whitespace (or comment)
 
 > Can be configured, see [configuration
-documentation](configuration.md#allow-case-trailing-whitespace) ([for
-comments](configuration.md#allow-trailing-comment))
+documentation](configuration.md#allow-trailing-comment)
 
 Having an empty trailing whitespace is unnecessary and makes the block
 definition looks never-ending long. You want to let reader know that the
@@ -139,6 +138,73 @@ Move the comment to the top.
 func example(y int) string {
     // TODO: add mux function later.
     return fmt.Sprintf("x")
+}
+```
+
+---
+
+### Case block should not end with a comment
+
+> Can be configured, see [configuration
+documentation](configuration.md#allow-trailing-comment)
+
+By default, case blocks should not end with a comment just like regular blocks.
+
+```go
+switch n {
+case 1:
+    fmt.Println("one")
+    // This is noise!
+case 2:
+    fmt.Println("two")
+}
+```
+
+#### Recommended amendment
+
+```go
+switch n {
+case 1: // I wonder how this will end?
+    fmt.Println("one")
+case 2:
+    fmt.Println("two")
+}
+```
+
+---
+
+### Case block should (never) end with newline at this size
+
+> Can be configured, see [configuration
+documentation](configuration.md#force-case-trailing-whitespace)
+
+This one is disabled by default by allowing the user to mix and match trailing
+whitespaces. If you encounter this issue someone (maybe you?) set this to a non
+0 value.
+
+To improve readability WSL can force to add or remote whitespaces based on a set
+limit. See link to configuration for options.
+
+With `force-case-trailing-whitespace` set to 1 this yields an error.
+
+```go
+switch n {
+case 1:
+    fmt.Println("one")
+case 2:
+    fmt.Println("two")
+}
+```
+
+#### Recommended amendment
+
+```go
+switch n {
+case 1:
+    fmt.Println("one")
+
+case 2:
+    fmt.Println("two")
 }
 ```
 

--- a/doc/rules.md
+++ b/doc/rules.md
@@ -143,47 +143,13 @@ func example(y int) string {
 
 ---
 
-### Case block should not end with a comment
-
-> Can be configured, see [configuration
-documentation](configuration.md#allow-trailing-comment)
-
-By default, case blocks should not end with a comment just like regular blocks.
-
-```go
-switch n {
-case 1:
-    fmt.Println("one")
-    // This is noise!
-case 2:
-    fmt.Println("two")
-}
-```
-
-#### Recommended amendment
-
-```go
-switch n {
-case 1: // I wonder how this will end?
-    fmt.Println("one")
-case 2:
-    fmt.Println("two")
-}
-```
-
----
-
-### Case block should (never) end with newline at this size
+### Case block should end with newline at this size
 
 > Can be configured, see [configuration
 documentation](configuration.md#force-case-trailing-whitespace)
 
-This one is disabled by default by allowing the user to mix and match trailing
-whitespaces. If you encounter this issue someone (maybe you?) set this to a non
-0 value.
-
-To improve readability WSL can force to add or remote whitespaces based on a set
-limit. See link to configuration for options.
+To improve readability WSL can force to add whitespaces based on a set limit.
+See link to configuration for options.
 
 With `force-case-trailing-whitespace` set to 1 this yields an error.
 
@@ -935,17 +901,6 @@ func IsNotZero(i int) string {
     return i != 0
 }
 ```
-
----
-
-### Stmt type not implemented
-
-Congratulations! You had found an unforseenable future detection. This hit
-simply means the detection is not implemented.
-
-#### Recommended amendment
-
-Raise an [issue](https://github.com/bombsimon/wsl/issues/new).
 
 ---
 

--- a/wsl_test.go
+++ b/wsl_test.go
@@ -1384,7 +1384,7 @@ func TestWithConfig(t *testing.T) {
 			},
 		},
 		{
-			description: "mix allowed, comments are not",
+			description: "case blocks can end with or without newlines and comments",
 			code: []byte(`package main
 
 			func main() {
@@ -1426,112 +1426,16 @@ func TestWithConfig(t *testing.T) {
 				CaseForceTrailingWhitespaceLimit: 0,
 				AllowTrailingComment:             false,
 			},
-			expectedErrorStrings: []string{
-				"case block should not end with a comment",
-				"case block should not end with a comment",
-			},
 		},
 		{
-			description: "always force newline, comments are not allowed",
+			description: "enforce newline at size 3",
 			code: []byte(`package main
 
 			func main() {
 				switch "x" {
 				case "a correct": // Test
 					fmt.Println("1")
-
-				case "a bad":
-					fmt.Println("1")
-				case "b correct":
-					fmt.Println("1")
-					fmt.Println("1")
-					fmt.Println("1")
-
-				case "b bad":
-					fmt.Println("1")
-					fmt.Println("1")
-					fmt.Println("1")
-				case "b bad":
-					fmt.Println("1")
-					// I'm not allowed'
-				case "b bad":
-					fmt.Println("1")
-					/*
-						I'm not allowed
-					*/
-				case "b bad":
-					fmt.Println("1")
-					/*
-						I'm not allowed
-					*/
-
-				case "end": // This is a case
-					fmt.Println("4")
-				}
-			}`),
-			customConfig: &Configuration{
-				CaseForceTrailingWhitespaceLimit: 1,
-				AllowTrailingComment:             false,
-			},
-			expectedErrorStrings: []string{
-				"case block should end with newline at this size",
-				"case block should end with newline at this size",
-				"case block should end with newline at this size",
-				"case block should not end with a comment",
-				"case block should end with newline at this size",
-				"case block should not end with a comment",
-				"case block should not end with a comment",
-			},
-		},
-		{
-			description: "mix allowed, comments allowed",
-			code: []byte(`package main
-
-			func main() {
-				switch "x" {
-				case "a correct": // Test
-					fmt.Println("1")
-
-				case "a correct":
-					fmt.Println("1")
-					// This is OK
-				case "b correct":
-					fmt.Println("1")
-					fmt.Println("1")
-					fmt.Println("1")
-					// This is OK
-
-				case "b bad":
-					fmt.Println("1")
-					fmt.Println("1")
-					fmt.Println("1")
-					// This is OK
-				case "b bad":
-					fmt.Println("1")
-					fmt.Println("1")
-					fmt.Println("1")
-					/*
-						This multiline
-						is OK
-					*/
-				case "end": // This is a case
-					fmt.Println("4")
-				}
-			}`),
-			customConfig: &Configuration{
-				CaseForceTrailingWhitespaceLimit: 0,
-				AllowTrailingComment:             true,
-			},
-		},
-		{
-			description: "only allow newline at 3 lines, comment's allowed",
-			code: []byte(`package main
-
-			func main() {
-				switch "x" {
-				case "a correct": // Test
-					fmt.Println("1")
-				case "a bad": // This is too short for a newline
+				case "a ok":
 					fmt.Println("1")
 
 				case "b correct":
@@ -1554,13 +1458,13 @@ func TestWithConfig(t *testing.T) {
 					fmt.Println("1")
 					fmt.Println("1")
 					// This is not OK, no whitespace
-				case "b bad":
+				case "b ok":
 					fmt.Println("1")
 					fmt.Println("1")
 					fmt.Println("1")
 					/*
 						This is not OK
-						Multiline but now whitespace
+						Multiline but no whitespace
 					*/
 				case "end": // This is a case
 					fmt.Println("4")
@@ -1571,7 +1475,6 @@ func TestWithConfig(t *testing.T) {
 				AllowTrailingComment:             true,
 			},
 			expectedErrorStrings: []string{
-				"case block should never end with newline at this size",
 				"case block should end with newline at this size",
 				"case block should end with newline at this size",
 				"case block should end with newline at this size",


### PR DESCRIPTION
Addresses #49.

This is (maybe) a WIP/POC. I spent a lot of time on this since I couldn't get the logic to be easy enough to make this obvious. And just when I thought that I had something going on I realised that I should probably split this up in two settings.

1. Force newlines at
2. Forbid newlines before

I'm not sure how to combine these but I'll use this PR to iterate proposals.