### PR TITLE
Fix golangci-lint cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ test files, use `-n` or `--no-test`.
 The recommended command is:
 
 ```sh
-golangci-lint --disable-all --enable wsl
+golangci-lint run --disable-all --enable wsl
 ```
 
 For more information, please refer to


### PR DESCRIPTION
I've fixed the golangci-lint cmd in the Readme. The previous one threw an error :)