### PR TITLE
Error check enforcement: Support inline initialization

### DIFF
--- a/wsl.go
+++ b/wsl.go
@@ -375,16 +375,13 @@ func (p *Processor) parseBlockStatements(statements []ast.Stmt) {
 		switch t := stmt.(type) {
 		case *ast.IfStmt:
 			checkingErrInitializedInline := func() bool {
-				if t.Init != nil {
-					// Variables were initialized inline in the if statement
-					// Let's make sure it's the err just to be safe
-					initLHS := p.findLHS(t.Init)
-					if atLeastOneInListsMatch(initLHS, p.config.ErrorVariableNames) {
-						// Err var was initialized and checked, no issue.
-						return true
-					}
+				if t.Init == nil {
+					return false
 				}
-				return false
+
+				// Variables were initialized inline in the if statement
+				// Let's make sure it's the err just to be safe
+				return atLeastOneInListsMatch(p.findLHS(t.Init), p.config.ErrorVariableNames)
 			}
 
 			if !cuddledWithLastStmt {

--- a/wsl_test.go
+++ b/wsl_test.go
@@ -1613,6 +1613,10 @@ func TestWithConfig(t *testing.T) {
 					return nil
 				}
 
+				if err := ProduceError(); err != nil {
+					return err
+				}
+
 				return baz
 			}`),
 			expectedErrorStrings: []string{},


### PR DESCRIPTION
Ran this against a large codebase at work this morning and the inline err-check false-positives are resolved. No more false positives, and our code looks beautiful!!

After I got this working I felt that the code was getting too nested, so I pulled the logic for this fix into a closure, LMK if you think there's a better place for that to be defined, or you would prefer the nesting instead of the closure. :)

Fixes false-positive reported in #65 