### PR TITLE
Avoid false positive on empty labels

### DIFF
--- a/wsl.go
+++ b/wsl.go
@@ -1138,7 +1138,24 @@ func (p *Processor) nodeStart(node ast.Node) int {
 }
 
 func (p *Processor) nodeEnd(node ast.Node) int {
-	return p.fileSet.Position(node.End()).Line
+	var line = p.fileSet.Position(node.End()).Line
+
+	if isEmptyLabeledStmt(node) {
+		return line - 1
+	}
+
+	return line
+}
+
+func isEmptyLabeledStmt(node ast.Node) bool {
+	v, ok := node.(*ast.LabeledStmt)
+	if !ok {
+		return false
+	}
+
+	_, empty := v.Stmt.(*ast.EmptyStmt)
+
+	return empty
 }
 
 // Add an error for the file and line number for the current token.Pos with the

--- a/wsl.go
+++ b/wsl.go
@@ -1141,7 +1141,7 @@ func (p *Processor) nodeEnd(node ast.Node) int {
 	var line = p.fileSet.Position(node.End()).Line
 
 	if isEmptyLabeledStmt(node) {
-		return line - 1
+		return p.fileSet.Position(node.Pos()).Line
 	}
 
 	return line

--- a/wsl_test.go
+++ b/wsl_test.go
@@ -65,6 +65,14 @@ func TestGenericHandling(t *testing.T) {
 				s := func() error { return nil }
 			}`),
 		},
+		{
+			description: "no false positives for empty labels",
+			code: []byte(`package main
+			func main() {
+				goto end;
+				end:
+			}`),
+		},
 	}
 
 	for _, tc := range cases {

--- a/wsl_test.go
+++ b/wsl_test.go
@@ -66,7 +66,7 @@ func TestGenericHandling(t *testing.T) {
 			}`),
 		},
 		{
-			description: "no false positives for empty labels",
+			description: "no false positives for empty labeled blocks",
 			code: []byte(`package main
 			func main() {
 				goto end;
@@ -207,6 +207,18 @@ func TestShouldRemoveEmptyLines(t *testing.T) {
 					}
 				}
 			}`),
+		},
+		{
+			description: "whitespaces parsed correctly in labeled blocks",
+			code: []byte(`package main
+			func main() {
+				goto end
+				end:
+
+			}`),
+			expectedErrorStrings: []string{
+				reasonBlockEndsWithWS,
+			},
 		},
 	}
 


### PR DESCRIPTION
Here's a solution to avoid false positives on empty labels.
Labels end position always falls into the next line, regardless if it is empty or not.
So for empty labels we simply could compensate the end position to avoid the false positive.

This solves #92