### PR TITLE
Better support for defer func literals

### DIFF
--- a/wsl_test.go
+++ b/wsl_test.go
@@ -1215,6 +1215,22 @@ func TestShouldAddEmptyLines(t *testing.T) {
 				reasonAssignsCuddleAssign,
 			},
 		},
+		{
+			description: "should allow defer func literals just like any block",
+			code: []byte(`package main
+
+			func main() {
+				tx := BeginTx(db)
+				defer func() {
+					EndTx(tx, err)
+				}()
+
+				i := 100
+				defer func() {
+					i = 0
+				}()
+			}`),
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
Will adress one of the examples in #85. This will no longer yield an error:

```go
tx := BeginTx(db)
defer func() {
    EndTx(tx, err)
}()

i := 100
defer func() {
    i = 0
}()
```