### PR TITLE
#102 allow forcing short declarations to cuddle only with themselves

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,5 +121,6 @@ feel free to raise an [issue](https://github.com/bombsimon/wsl/issues/new).
 * [Only one cuddle assignment allowed before type switch statement](doc/rules.md#only-one-cuddle-assignment-allowed-before-type-switch-statement)
 * [Ranges should only be cuddled with assignments used in the iteration](doc/rules.md#ranges-should-only-be-cuddled-with-assignments-used-in-the-iteration)
 * [Return statements should not be cuddled if block has more than two lines](doc/rules.md#return-statements-should-not-be-cuddled-if-block-has-more-than-two-lines)
+* [Short declarations should cuddle only with other short declarations](doc/rules.md#short-declaration-should-cuddle-only-with-other-short-declarations)
 * [Switch statements should only be cuddled with variables switched](doc/rules.md#switch-statements-should-only-be-cuddled-with-variables-switched)
 * [Type switch statements should only be cuddled with variables switched](doc/rules.md#type-switch-statements-should-only-be-cuddled-with-variables-switched)

--- a/cmd/wsl/main.go
+++ b/cmd/wsl/main.go
@@ -38,6 +38,7 @@ func main() {
 	flag.BoolVar(&config.AllowTrailingComment, "allow-trailing-comment", false, "Allow blocks to end with a comment")
 	flag.BoolVar(&config.AllowSeparatedLeadingComment, "allow-separated-leading-comment", false, "Allow empty newlines in leading comments")
 	flag.BoolVar(&config.ForceCuddleErrCheckAndAssign, "force-err-cuddling", false, "Force cuddling of error checks with error var assignment")
+	flag.BoolVar(&config.ForceExclusiveShortDeclarations, "force-short-decl-cuddling", false, "Force short declarations to cuddle by themselves")
 	flag.IntVar(&config.ForceCaseTrailingWhitespaceLimit, "force-case-trailing-whitespace", 0, "Force newlines for case blocks > this number.")
 
 	flag.Parse()

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -296,3 +296,41 @@ if err != nil {
     return err
 }
 ```
+
+### [force-short-decl-cuddling](rules.md#short-declaration-should-cuddle-only-with-other-short-declarations)
+
+Enforces that an assignment which is actually a short declaration (using `:=`)
+is only allowed to cuddle with other short declarations, and not plain
+assignments, blocks, etc. This rule helps make declarations stand out by
+themselves, much the same as grouping `var` statements.
+
+> Default value: false
+
+Supported when false:
+
+```go
+a := 1
+a = 2
+
+err := ErrorProducingFunc()
+if err != nil {
+    return err
+}
+```
+
+Required when true:
+
+```go
+a := 1
+
+a = 2
+
+err := ErrorProducingFunc()
+
+if err != nil {
+    return err
+}
+```
+
+**Note**: this means the option _overrides_ the 
+[enforce-err-cuddling](#enforce-err-cuddling) option above, among others.

--- a/doc/rules.md
+++ b/doc/rules.md
@@ -1013,3 +1013,38 @@ if err != nil {
     return err
 }
 ```
+
+---
+
+### Short declaration should cuddle only with other short declarations
+
+> Can be configured, see [configuration
+documentation](configuration.md#force-short-decl-cuddling)
+
+A short declaration (an "assignment" using `:=`) must not be cuddled with anything other than another short declaration.
+
+```go
+a := 1
+err := ErrorProducingFunc()
+if err != nil {
+    return err
+}
+```
+
+#### Recommended amendment
+
+Add an empty line between the short declaration and the error check.
+
+```go
+a := 1
+err := ErrorProducingFunc()
+
+if err != nil {
+    return err
+}
+```
+
+**Note**: this is the opposite of the case above forcing an `err` variable
+to be assigned together with its check; it also overrides some other rules
+which about assignments by separating short declarations from "plain"
+assignment statements using `=`.

--- a/wsl.go
+++ b/wsl.go
@@ -921,17 +921,10 @@ func (p *Processor) findRHS(node ast.Node) []string {
 }
 
 func (p *Processor) isShortDecl(node ast.Node) bool {
-	if node == nil {
-		return false
+	if t, ok := node.(*ast.AssignStmt); ok {
+		return t.Tok == token.DEFINE
 	}
-
-	switch t := node.(type) {
-	case *ast.AssignStmt:
-		if t.Tok == token.DEFINE {
-			return true
-		}
-	}
-
+	
 	return false
 }
 

--- a/wsl.go
+++ b/wsl.go
@@ -413,13 +413,9 @@ func (p *Processor) parseBlockStatements(statements []ast.Stmt) {
 		// it was and use *that* statement's position
 		if p.config.ForceExclusiveShortDeclarations && cuddledWithLastStmt {
 			if p.isShortDecl(stmt) && !p.isShortDecl(previousStatement) {
-				t := stmt.(*ast.AssignStmt)
-
-				p.addError(t.Pos(), reasonShortDeclNotExclusive)
+				p.addError(stmt.Pos(), reasonShortDeclNotExclusive)
 			} else if p.isShortDecl(previousStatement) && !p.isShortDecl(stmt) {
-				t := previousStatement.(*ast.AssignStmt)
-
-				p.addError(t.Pos(), reasonShortDeclNotExclusive)
+				p.addError(previousStatement.Pos(), reasonShortDeclNotExclusive)
 			}
 		}
 
@@ -924,7 +920,7 @@ func (p *Processor) isShortDecl(node ast.Node) bool {
 	if t, ok := node.(*ast.AssignStmt); ok {
 		return t.Tok == token.DEFINE
 	}
-	
+
 	return false
 }
 

--- a/wsl_test.go
+++ b/wsl_test.go
@@ -1828,6 +1828,35 @@ func TestWithConfig(t *testing.T) {
 				reasonOnlyOneCuddle,
 			},
 		},
+		{
+			description: "force short decls to cuddle alone",
+			code: []byte(`package main
+
+			func main() {
+                // OK
+				a := 1
+                b := 2
+
+                // should fail
+				c := 3
+                b = 2
+
+                // should fail 
+                err := DoSomething()
+                if err != nil {
+                    b = 4
+                }
+			}`),
+			customConfig: &Configuration{
+				AllowAssignAndAnythingCuddle:    true,
+				ForceCuddleErrCheckAndAssign:    true,
+				ForceExclusiveShortDeclarations: true,
+			},
+			expectedErrorStrings: []string{
+				reasonShortDeclNotExclusive,
+				reasonShortDeclNotExclusive,
+			},
+		},
 	}
 
 	for _, tc := range cases {

--- a/wsl_test.go
+++ b/wsl_test.go
@@ -1833,19 +1833,19 @@ func TestWithConfig(t *testing.T) {
 			code: []byte(`package main
 
 			func main() {
-                // OK
+				// OK
 				a := 1
-                b := 2
+				b := 2
 
-                // should fail
+				// should fail
 				c := 3
-                b = 2
+				b = 2
 
-                // should fail 
-                err := DoSomething()
-                if err != nil {
-                    b = 4
-                }
+				// should fail 
+				err := DoSomething()
+				if err != nil {
+					b = 4
+				}
 			}`),
 			customConfig: &Configuration{
 				AllowAssignAndAnythingCuddle:    true,


### PR DESCRIPTION
This option treats a short declaration with := as different than a plain
assignment with = and so prevents them cuddling together, as well as not
allowing a short declaration to cuddle with a block, for example.