### PR TITLE
#104 allow a blank line after each comment group at the start of a block

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -133,6 +133,36 @@ assignmentTwo := "so I cannot be cuddled"
 assignmentThree := "this is fine"
 ```
 
+### [allow-separated-leading-comment](rules.md#block-should-not-start-with-a-whitespace)
+
+This option allows whitespace after each comment group that begins a block.
+
+> Default value: false
+
+For example,
+
+```go
+func example() string {
+  // comment
+
+  return fmt.Sprintf("x")
+}
+```
+
+and
+
+```go
+func example() string {
+  // comment
+
+  // comment
+  return fmt.Sprintf("x")
+}
+```
+
+become legal, as the whitespace _after_ (or between) each comment block 
+doesn't count against whitespace before the first actual statement.
+
 ### [force-case-trailing-whitespace](rules.md#case-block-should-end-with-newline-at-this-size)
 
 Can be set to force trailing newlines at the end of case blocks to improve

--- a/doc/rules.md
+++ b/doc/rules.md
@@ -202,6 +202,31 @@ func example() string {
 }
 ```
 
+> However, this can be configured to allow white space after one
+> or more initial comment groups, see
+[configuration documentation](configuration.md#allow-separated-leading-comment)
+>
+> If that is done, then these examples are allowed:
+
+```go
+  func example() string {
+  // comment
+
+  return fmt.Sprintf("x")
+}
+```
+
+> and
+
+```go
+  func example() string {
+  // comment
+
+  // comment
+  return fmt.Sprintf("x")
+}
+```
+
 ---
 
 ### Branch statements should not be cuddled if block has more than two lines

--- a/wsl.go
+++ b/wsl.go
@@ -1065,7 +1065,6 @@ func (p *Processor) findLeadingAndTrailingWhitespaces(ident *ast.Ident, stmt, ne
 	// And now if the first statement is passed the number of allowed lines,
 	// then we had extra WS, possibly before the first comment group.
 	if p.nodeStart(firstStatement) > blockStartLine+allowedLinesBeforeFirstStatement {
-		fmt.Printf("error: p.nodeStart(firstStatement)=%d, blockStartLine+allowedLinesBeforeFirstStatement=%d\n", p.nodeStart(firstStatement), blockStartLine+allowedLinesBeforeFirstStatement)
 		p.addError(
 			blockStartPos,
 			reasonBlockStartsWithWS,

--- a/wsl.go
+++ b/wsl.go
@@ -1034,8 +1034,17 @@ func (p *Processor) findLeadingAndTrailingWhitespaces(ident *ast.Ident, stmt, ne
 			}
 
 			// We store number of seen comment groups because we allow multiple
-			// groups with a newline between them.
-			seenCommentGroups++
+			// groups with a newline between them; but if the first one has WS
+			// before it, we're not going to count it to force an error.
+			if p.config.AllowSeparatedLeadingComment {
+				cg := p.fileSet.Position(commentGroup.Pos()).Line
+
+				if seenCommentGroups > 0 || cg == blockStartLine+1 {
+					seenCommentGroups++
+				}
+			} else {
+				seenCommentGroups++
+			}
 
 			// Support both /* multiline */ and //single line comments
 			for _, c := range commentGroup.List {
@@ -1044,14 +1053,19 @@ func (p *Processor) findLeadingAndTrailingWhitespaces(ident *ast.Ident, stmt, ne
 		}
 	}
 
-	// If we have multiple groups, add support for newline between each group.
+	// If we allow separated comments, allow for a space after each group
 	if p.config.AllowSeparatedLeadingComment {
 		if seenCommentGroups > 1 {
 			allowedLinesBeforeFirstStatement += seenCommentGroups - 1
+		} else if seenCommentGroups == 1 {
+			allowedLinesBeforeFirstStatement += 1
 		}
 	}
 
-	if p.nodeStart(firstStatement) != blockStartLine+allowedLinesBeforeFirstStatement {
+	// And now if the first statement is passed the number of allowed lines,
+	// then we had extra WS, possibly before the first comment group.
+	if p.nodeStart(firstStatement) > blockStartLine+allowedLinesBeforeFirstStatement {
+		fmt.Printf("error: p.nodeStart(firstStatement)=%d, blockStartLine+allowedLinesBeforeFirstStatement=%d\n", p.nodeStart(firstStatement), blockStartLine+allowedLinesBeforeFirstStatement)
 		p.addError(
 			blockStartPos,
 			reasonBlockStartsWithWS,

--- a/wsl_test.go
+++ b/wsl_test.go
@@ -1732,7 +1732,71 @@ func TestWithConfig(t *testing.T) {
 					*/
 					fmt.Println("Hello, World")
 				}
+
+				func () { // Comment
+					// and one more
+
+					fmt.Println("Hello, World")
+				}
+
+				func () { // Comment
+					fmt.Println("Hello, World")
+				}
 			}`),
+		},
+		{
+			description: "allow separated leading comment (negative)",
+			customConfig: &Configuration{
+				AllowSeparatedLeadingComment: true,
+			},
+			code: []byte(`package main
+
+			func main() {
+				// These blocks should generate error
+				func () {
+
+					// Comment
+
+					// Comment
+					fmt.Println("Hello, World")
+				}
+
+				func () {
+
+					fmt.Println("Hello, World")
+				}
+
+				func () {
+					// Comment
+
+
+					fmt.Println("Hello, World")
+				}
+
+				func () {
+					// Comment
+
+					// Comment
+
+
+					fmt.Println("Hello, World")
+				}
+
+				func () { // Comment
+
+					/*
+						Multiline
+					*/
+					fmt.Println("Hello, World")
+				}
+			}`),
+			expectedErrorStrings: []string{
+				reasonBlockStartsWithWS,
+				reasonBlockStartsWithWS,
+				reasonBlockStartsWithWS,
+				reasonBlockStartsWithWS,
+				reasonBlockStartsWithWS,
+			},
 		},
 		{
 			description: "only warn about cuddling errors if it's an expression above",


### PR DESCRIPTION
OK, figured it out. It's tricky, because the code allowed a space between groups, but we need to allow a space after each group. So the logic changes to take into account whether there's a break before the first group and to handle the case of just one group.

I've added a couple additional positive cases and a set of negative cases to show this works. Also added docs.