### PR TITLE
fix: add modules /v3 suffix to install example

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ make something configurable!
 You can do that by using:
 
 ```sh
-go get -u github.com/bombsimon/wsl/cmd/...
+go get -u github.com/bombsimon/wsl/v3/cmd/...
 ```
 
 ### By golangci-lint (CI automation)


### PR DESCRIPTION
The previous example in the README installed 1.2.8 rather than the
latest 3.x series