### PR TITLE
Add *ast.KeyValueExpr as a source for RHS varaibles

### DIFF
--- a/wsl.go
+++ b/wsl.go
@@ -845,8 +845,7 @@ func (p *Processor) findRHS(node ast.Node) []string {
 	case *ast.BasicLit, *ast.SelectStmt, *ast.ChanType,
 		*ast.LabeledStmt, *ast.DeclStmt, *ast.BranchStmt,
 		*ast.TypeSpec, *ast.ArrayType, *ast.CaseClause,
-		*ast.CommClause, *ast.KeyValueExpr, *ast.MapType,
-		*ast.FuncLit:
+		*ast.CommClause, *ast.MapType, *ast.FuncLit:
 	// Nothing to add to RHS
 	case *ast.Ident:
 		return []string{t.Name}
@@ -905,6 +904,9 @@ func (p *Processor) findRHS(node ast.Node) []string {
 		rhs = append(rhs, p.findRHS(t.X)...)
 		rhs = append(rhs, p.findRHS(t.Low)...)
 		rhs = append(rhs, p.findRHS(t.High)...)
+	case *ast.KeyValueExpr:
+		rhs = p.findRHS(t.Key)
+		rhs = append(rhs, p.findRHS(t.Value)...)
 	default:
 		if x, ok := maybeX(t); ok {
 			return p.findRHS(x)

--- a/wsl_test.go
+++ b/wsl_test.go
@@ -1921,6 +1921,19 @@ func TestWithConfig(t *testing.T) {
 				reasonShortDeclNotExclusive,
 			},
 		},
+		{
+			description: "key value pairs can use variables",
+			code: []byte(`package main
+
+			func main() {
+				someData := GetSomeData()
+				log.WithFields(log.Fields{
+					"data1": someData.One,
+					"data2": someData.Two,
+					"data3": someData.Three,
+				}).Debug("Got some data")
+			}`),
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
Key-value expressions can use variables both as keys and values so we
must parse them to check for assigned and used variables.

Fixes #106