### PR TITLE
Rework config and setup

### DIFF
--- a/cmd/wsl/main.go
+++ b/cmd/wsl/main.go
@@ -6,5 +6,5 @@ import (
 )
 
 func main() {
-	singlechecker.Main(wsl.Analyzer)
+	singlechecker.Main(wsl.NewAnalyzer(nil))
 }

--- a/wsl_test.go
+++ b/wsl_test.go
@@ -1,7 +1,6 @@
 package wsl
 
 import (
-	"flag"
 	"path/filepath"
 	"testing"
 
@@ -10,98 +9,91 @@ import (
 
 func TestWIP(t *testing.T) {
 	testdata := analysistest.TestData()
-	analyzer := Analyzer
-	analyzer.Flags = flags()
+	analyzer := NewAnalyzer(nil)
 
 	analysistest.RunWithSuggestedFixes(t, testdata, analyzer, "wip")
 }
 
 func TestDefaultConfig(t *testing.T) {
 	testdata := analysistest.TestData()
-	analyzer := Analyzer
-	analyzer.Flags = flags()
+	analyzer := NewAnalyzer(nil)
 
 	analysistest.RunWithSuggestedFixes(t, testdata, analyzer, "default_config")
 }
 
 func TestWithConfig(t *testing.T) {
-	defaultConfig := config
-
-	flags := flag.NewFlagSet("", flag.ExitOnError)
-
 	testdata := analysistest.TestData()
-	analyzer := Analyzer
-	analyzer.Flags = *flags
 
 	for _, tc := range []struct {
 		subdir   string
-		configFn func()
+		configFn func(*Configuration)
 	}{
 		{
 			subdir: "case_blocks",
-			configFn: func() {
+			configFn: func(config *Configuration) {
 				config.ForceCaseTrailingWhitespaceLimit = 3
 			},
 		},
 		{
 			subdir: "multi_line_assign",
-			configFn: func() {
+			configFn: func(config *Configuration) {
 				config.AllowMultiLineAssignCuddle = false
 			},
 		},
 		{
 			subdir: "assign_and_call",
-			configFn: func() {
+			configFn: func(config *Configuration) {
 				config.AllowAssignAndCallCuddle = false
 			},
 		},
 		{
 			subdir: "trailing_comments",
-			configFn: func() {
+			configFn: func(config *Configuration) {
 				config.AllowTrailingComment = true
 			},
 		},
 		{
 			subdir: "separate_leading_whitespace",
-			configFn: func() {
+			configFn: func(config *Configuration) {
 				config.AllowSeparatedLeadingComment = true
 			},
 		},
 		{
 			subdir: "error_check",
-			configFn: func() {
+			configFn: func(config *Configuration) {
 				config.ForceCuddleErrCheckAndAssign = true
 			},
 		},
 		{
 			subdir: "short_decl",
-			configFn: func() {
+			configFn: func(config *Configuration) {
 				config.ForceExclusiveShortDeclarations = true
 			},
 		},
 		{
 			subdir: "strict_append",
-			configFn: func() {
+			configFn: func(config *Configuration) {
 				config.StrictAppend = false
 			},
 		},
 		{
 			subdir: "assign_and_anything",
-			configFn: func() {
+			configFn: func(config *Configuration) {
 				config.AllowAssignAndAnythingCuddle = true
 			},
 		},
 		{
 			subdir: "decl",
-			configFn: func() {
+			configFn: func(config *Configuration) {
 				config.AllowCuddleDeclaration = true
 			},
 		},
 	} {
 		t.Run(tc.subdir, func(t *testing.T) {
-			config = defaultConfig
-			tc.configFn()
+			config := defaultConfig()
+			tc.configFn(config)
 
+			analyzer := NewAnalyzer(config)
 			analysistest.RunWithSuggestedFixes(t, testdata, analyzer, filepath.Join("with_config", tc.subdir))
 		})
 	}


### PR DESCRIPTION
Avoid global variables by adding a constructor for the analyzer. At the same time, accept configuration as an input to not mutate a global var, or pass nil to set the configuration through flags.