### PR TITLE
Use `PositonFor` to ignore `//line` directives

### DIFF
--- a/analyzer.go
+++ b/analyzer.go
@@ -75,7 +75,7 @@ func (wa *wslAnalyzer) flags() flag.FlagSet {
 
 func (wa *wslAnalyzer) run(pass *analysis.Pass) (interface{}, error) {
 	for _, file := range pass.Files {
-		filename := pass.Fset.Position(file.Pos()).Filename
+		filename := pass.Fset.PositionFor(file.Pos(), false).Filename
 		if !strings.HasSuffix(filename, ".go") {
 			continue
 		}

--- a/wsl.go
+++ b/wsl.go
@@ -1108,8 +1108,8 @@ func (p *processor) findLeadingAndTrailingWhitespaces(ident *ast.Ident, stmt, ne
 		return
 	}
 
-	blockStartLine = p.fileSet.Position(blockStartPos).Line
-	blockEndLine = p.fileSet.Position(blockEndPos).Line
+	blockStartLine = p.fileSet.PositionFor(blockStartPos, false).Line
+	blockEndLine = p.fileSet.PositionFor(blockEndPos, false).Line
 
 	// No whitespace possible if LBrace and RBrace is on the same line.
 	if blockStartLine == blockEndLine {
@@ -1357,14 +1357,14 @@ func isExampleFunc(ident *ast.Ident) bool {
 }
 
 func (p *processor) nodeStart(node ast.Node) int {
-	return p.fileSet.Position(node.Pos()).Line
+	return p.fileSet.PositionFor(node.Pos(), false).Line
 }
 
 func (p *processor) nodeEnd(node ast.Node) int {
-	line := p.fileSet.Position(node.End()).Line
+	line := p.fileSet.PositionFor(node.End(), false).Line
 
 	if isEmptyLabeledStmt(node) {
-		return p.fileSet.Position(node.Pos()).Line
+		return p.fileSet.PositionFor(node.Pos(), false).Line
 	}
 
 	return line
@@ -1403,7 +1403,7 @@ func (p *processor) addErrorRange(reportAt, start, end token.Pos, reason string)
 }
 
 func (p *processor) addWarning(w string, pos token.Pos, t interface{}) {
-	position := p.fileSet.Position(pos)
+	position := p.fileSet.PositionFor(pos, false)
 
 	p.warnings = append(p.warnings,
 		fmt.Sprintf("%s:%d: %s (%T)", position.Filename, position.Line, w, t),


### PR DESCRIPTION
This is especially important in `analyzer.go` where we need to get the filename of the actual file so we can skip non Go files. This is used to skip the cached generated test files that are passed from the `GOCACHE`