### PR TITLE
Fix installation instruction for the latest release

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ make something configurable!
 
 ```sh
 # Latest release
-go install github.com/bombsimon/wsl/v4/cmd/wsl
+go install github.com/bombsimon/wsl/v4/cmd/wsl@latest
 
 # Main branch
 go install github.com/bombsimon/wsl/v4/cmd/wsl@master


### PR DESCRIPTION
This PR fixes installation instruction for the latest release in README.

Without `@latest` you get:

```
❯ go install github.com/bombsimon/wsl/v4/cmd/wsl

go: 'go install' requires a version when current directory is not in a module
        Try 'go install github.com/bombsimon/wsl/v4/cmd/wsl@latest' to install the latest version
```