### PR TITLE
Set golangci-lint version in CI to avoid new lint issues

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,6 +14,8 @@ jobs:
         with:
           go-version: stable
       - uses: golangci/golangci-lint-action@v4
+        with:
+          version: v1.57.2
 
   tests:
     # run after golangci-lint action to not produce duplicated errors


### PR DESCRIPTION
This PR pins the version of golangci-lint in CI to prevent new lint issues from arising when a new version of golangci-lint is released. See this failing action https://github.com/bombsimon/wsl/actions/runs/9227623841/job/25389954280?pr=150