### PR TITLE
fix: ignore cgo files

### DIFF
--- a/analyzer.go
+++ b/analyzer.go
@@ -86,8 +86,12 @@ func (wa *wslAnalyzer) run(pass *analysis.Pass) (interface{}, error) {
 			continue
 		}
 
-		// if the file is related to cgo the filename of the unadjusted position is a not a '.go' file.
 		fn := pass.Fset.PositionFor(file.Pos(), false).Filename
+
+		// if the file is related to cgo the filename of the unadjusted position is a not a '.go' file.
+		if !strings.HasSuffix(fn, ".go") {
+			continue
+		}
 
 		// The file is skipped if the "unadjusted" file is a Go file, and it's a generated file (ex: "_test.go" file).
 		// The other non-Go files are skipped by the first 'if' with the adjusted position.

--- a/testdata/src/default_config/cgo/cgo.go
+++ b/testdata/src/default_config/cgo/cgo.go
@@ -22,16 +22,16 @@ func _() {
 
 func Advanced() {
 	var foo = 1
-	var bar = 2 // want "declarations should never be cuddled"
-	var biz int // want "declarations should never be cuddled"
+	var bar = 2
+	var biz int
 
 	x := []string{}
 	x = append(x, "literal")
 	notUsed := "just assigning, don't mind me"
-	x = append(x, "not z..") // want "append only allowed to cuddle with appended value"
+	x = append(x, "not z..")
 	useMe := "right away"
 	alsoNotUsed := ":("
-	x = append(x, "just noise") // want "append only allowed to cuddle with appended value"
+	x = append(x, "just noise")
 	x = append(x, useMe)
 
 	_ = foo


### PR DESCRIPTION
Reverts #159, #157

the cgo support is dropped, but the tests are kept to avoid regression.

Fixes #162
