### PR TITLE
Improve fixer for `DeclStmt`

### DIFF
--- a/CHECKS.md
+++ b/CHECKS.md
@@ -121,9 +121,8 @@ together they should be declared in the same group with parenthesis into a
 single statement. The benefit of this is that it also aligns the declaration or
 assignment increasing readability.
 
-> **NOTE** The fixer can't do smart adjustments and currently only add
-> whitespaces.
-> This is tracked in [#21](https://github.com/bombsimon/wsl/issues/121)
+> **NOTE** The fixer can't do smart adjustments if there are comments on the
+> same line as the declaration.
 
 <table>
 <thead><tr><th>Bad</th><th>Good</th></tr></thead>

--- a/analyzer.go
+++ b/analyzer.go
@@ -117,7 +117,7 @@ func (wa *wslAnalyzer) run(pass *analysis.Pass) (any, error) {
 				textEdits = append(textEdits, analysis.TextEdit{
 					Pos:     f.fixRangeStart,
 					End:     f.fixRangeEnd,
-					NewText: []byte("\n"),
+					NewText: f.fix,
 				})
 			}
 

--- a/cursor.go
+++ b/cursor.go
@@ -25,6 +25,17 @@ func (c *Cursor) SetChecker(ct CheckType) {
 	c.checkType = ct
 }
 
+func (c *Cursor) NextNode() ast.Node {
+	defer c.Save()()
+
+	var nextNode ast.Node
+	if c.Next() {
+		nextNode = c.Stmt()
+	}
+
+	return nextNode
+}
+
 func (c *Cursor) Next() bool {
 	if c.currentIdx >= len(c.statements)-1 {
 		return false

--- a/testdata/src/default_config/decl/decl.go
+++ b/testdata/src/default_config/decl/decl.go
@@ -78,3 +78,15 @@ func fn6() {
 	var d = 4
 	var e = 5
 }
+
+func fn7() {
+	// want +2 `missing whitespace above this line \(never cuddle decl\)`
+	var a = 1
+	var b = 2
+
+	var c = 3
+
+	// want +2 `missing whitespace above this line \(never cuddle decl\)`
+	var d = 4
+	var e = 5
+}

--- a/testdata/src/default_config/decl/decl.go
+++ b/testdata/src/default_config/decl/decl.go
@@ -119,3 +119,21 @@ func fn10() {
 	var e string = "string"
 	f := 3 // want `missing whitespace above this line \(invalid statement above assign\)`
 }
+
+func fn11() {
+ 	// want +2 `missing whitespace above this line \(never cuddle decl\)`
+	var a int
+	var b int
+	if b > 0 { // want `missing whitespace above this line \(too many statements above if\)`
+		_ = 1
+	}
+}
+
+func fn12() {
+	// want +2 `missing whitespace above this line \(never cuddle decl\)`
+	var a int
+	var b int // Split by comma
+	if b > 0 {
+		_ = 1
+	}
+}

--- a/testdata/src/default_config/decl/decl.go
+++ b/testdata/src/default_config/decl/decl.go
@@ -132,7 +132,7 @@ func fn11() {
 func fn12() {
 	// want +2 `missing whitespace above this line \(never cuddle decl\)`
 	var a int
-	var b int // Split by comma
+	var b int // Not grouped due to this comment
 	if b > 0 {
 		_ = 1
 	}

--- a/testdata/src/default_config/decl/decl.go
+++ b/testdata/src/default_config/decl/decl.go
@@ -107,3 +107,15 @@ func fn9() {
 		N int
 	}
 }
+
+func fn10() {
+ 	// want +5 `missing whitespace above this line \(never cuddle decl\)`
+ 	// want +5 `missing whitespace above this line \(never cuddle decl\)`
+ 	// want +5 `missing whitespace above this line \(never cuddle decl\)`
+	a := 1
+	b := 2
+	var c int
+	var d = "string"
+	var e string = "string"
+	f := 3 // want `missing whitespace above this line \(invalid statement above assign\)`
+}

--- a/testdata/src/default_config/decl/decl.go
+++ b/testdata/src/default_config/decl/decl.go
@@ -90,3 +90,11 @@ func fn7() {
 	var d = 4
 	var e = 5
 }
+
+func fn8() {
+ 	// want +3 `missing whitespace above this line \(never cuddle decl\)`
+	// Comment above
+	var g = 7
+	var h = 8
+	// Comment after
+}

--- a/testdata/src/default_config/decl/decl.go
+++ b/testdata/src/default_config/decl/decl.go
@@ -98,3 +98,12 @@ func fn8() {
 	var h = 8
 	// Comment after
 }
+
+func fn9() {
+	type S1 struct {
+		N int
+	}
+	type S2 struct { // want `missing whitespace above this line \(never cuddle decl\)`
+		N int
+	}
+}

--- a/testdata/src/default_config/decl/decl.go
+++ b/testdata/src/default_config/decl/decl.go
@@ -1,30 +1,80 @@
 package testpkg
 
 func fn1() {
+ 	// want +2 `missing whitespace above this line \(never cuddle decl\)`
 	var a = 1
-	var b = 2 // want `missing whitespace above this line \(never cuddle decl\)`
+	var b = 2
 
+ 	// want +2 `missing whitespace above this line \(never cuddle decl\)`
 	const c = 3
-	const d = 4 // want `missing whitespace above this line \(never cuddle decl\)`
+	const d = 4
 
+	// want +3 `missing whitespace above this line \(never cuddle decl\)`
+	// want +3 `missing whitespace above this line \(invalid statement above assign\)`
 	e := 5
-	var f = 6 // want `missing whitespace above this line \(never cuddle decl\)`
-	g := 7 // want `missing whitespace above this line \(invalid statement above assign\)`
+	var f = 6
+	g := 7
+
+	// want +2 `missing whitespace above this line \(never cuddle decl\)`
+	var a = 1
+	var b = a
 }
 
 func fn2() {
-	var a = 1
-	var b = a // want `missing whitespace above this line \(never cuddle decl\)`
-}
-
-func fn3() {
-	a := 1
-	var b = a // want `missing whitespace above this line \(never cuddle decl\)`
-}
-
-func fn4() {
 	var x = func() { // want +1 `unnecessary whitespace \(leading-whitespace\)`
 
 		return 1
 	}()
+}
+
+func fn3() {
+	// want +4 `missing whitespace above this line \(never cuddle decl\)`
+	// want +4 `missing whitespace above this line \(never cuddle decl\)`
+	// want +4 `missing whitespace above this line \(never cuddle decl\)`
+	var a = 1
+	var b = 2
+	var c = 3
+	var d = 4
+}
+
+func fn4() {
+	// want +5 `missing whitespace above this line \(never cuddle decl\)`
+	var (
+		a = 1
+		b = 2
+	)
+	var (
+		c = 3
+		d = 4
+	)
+}
+
+func fn5() {
+	// want +7 `missing whitespace above this line \(never cuddle decl\)`
+	// want +7 `missing whitespace above this line \(never cuddle decl\)`
+	// want +9 `missing whitespace above this line \(never cuddle decl\)`
+	var (
+		a = 1
+		b = 2
+	)
+	var x int
+	var z = func() int {
+		return 1
+	}
+	var (
+		c = 3
+		d = 4
+	)
+}
+
+func fn6() {
+	// want +5 `missing whitespace above this line \(never cuddle decl\)`
+	// want +5 `missing whitespace above this line \(never cuddle decl\)`
+	// want +5 `missing whitespace above this line \(never cuddle decl\)`
+	// want +5 `missing whitespace above this line \(never cuddle decl\)`
+	var a = 1
+	var b = 2
+	var c = 3 // test
+	var d = 4
+	var e = 5
 }

--- a/testdata/src/default_config/decl/decl.go.golden
+++ b/testdata/src/default_config/decl/decl.go.golden
@@ -141,3 +141,25 @@ func fn10() {
 
 	f := 3 // want `missing whitespace above this line \(invalid statement above assign\)`
 }
+
+func fn11() {
+ 	// want +2 `missing whitespace above this line \(never cuddle decl\)`
+	var (
+		a int
+		b int
+	)
+
+	if b > 0 { // want `missing whitespace above this line \(too many statements above if\)`
+		_ = 1
+	}
+}
+
+func fn12() {
+ 	// want +2 `missing whitespace above this line \(never cuddle decl\)`
+	var a int
+
+	var b int // Split by comma
+	if b > 0 {
+		_ = 1
+	}
+}

--- a/testdata/src/default_config/decl/decl.go.golden
+++ b/testdata/src/default_config/decl/decl.go.golden
@@ -115,3 +115,13 @@ func fn8() {
 	)
 	// Comment after
 }
+
+func fn9() {
+	type S1 struct {
+		N int
+	}
+
+	type S2 struct { // want `missing whitespace above this line \(never cuddle decl\)`
+		N int
+	}
+}

--- a/testdata/src/default_config/decl/decl.go.golden
+++ b/testdata/src/default_config/decl/decl.go.golden
@@ -1,35 +1,91 @@
 package testpkg
 
 func fn1() {
-	var a = 1
+ 	// want +2 `missing whitespace above this line \(never cuddle decl\)`
+	var (
+		a = 1
+		b = 2
+	)
 
-	var b = 2 // want `missing whitespace above this line \(never cuddle decl\)`
+ 	// want +2 `missing whitespace above this line \(never cuddle decl\)`
+	const (
+		c = 3
+		d = 4
+	)
 
-	const c = 3
-
-	const d = 4 // want `missing whitespace above this line \(never cuddle decl\)`
-
+	// want +3 `missing whitespace above this line \(never cuddle decl\)`
+	// want +3 `missing whitespace above this line \(invalid statement above assign\)`
 	e := 5
 
-	var f = 6 // want `missing whitespace above this line \(never cuddle decl\)`
+	var f = 6
 
-	g := 7 // want `missing whitespace above this line \(invalid statement above assign\)`
+	g := 7
+
+	// want +2 `missing whitespace above this line \(never cuddle decl\)`
+	var (
+		a = 1
+		b = a
+	)
 }
 
 func fn2() {
-	var a = 1
-
-	var b = a // want `missing whitespace above this line \(never cuddle decl\)`
-}
-
-func fn3() {
-	a := 1
-
-	var b = a // want `missing whitespace above this line \(never cuddle decl\)`
-}
-
-func fn4() {
 	var x = func() { // want +1 `unnecessary whitespace \(leading-whitespace\)`
 		return 1
 	}()
+}
+
+func fn3() {
+	// want +4 `missing whitespace above this line \(never cuddle decl\)`
+	// want +4 `missing whitespace above this line \(never cuddle decl\)`
+	// want +4 `missing whitespace above this line \(never cuddle decl\)`
+	var (
+		a = 1
+		b = 2
+		c = 3
+		d = 4
+	)
+}
+
+func fn4() {
+	// want +5 `missing whitespace above this line \(never cuddle decl\)`
+	var (
+		a = 1
+		b = 2
+		c = 3
+		d = 4
+	)
+}
+
+func fn5() {
+	// want +7 `missing whitespace above this line \(never cuddle decl\)`
+	// want +7 `missing whitespace above this line \(never cuddle decl\)`
+	// want +9 `missing whitespace above this line \(never cuddle decl\)`
+	var (
+		a = 1
+		b = 2
+		x int
+		z = func() int {
+			return 1
+		}
+		c = 3
+		d = 4
+	)
+}
+
+func fn6() {
+	// want +5 `missing whitespace above this line \(never cuddle decl\)`
+	// want +5 `missing whitespace above this line \(never cuddle decl\)`
+	// want +5 `missing whitespace above this line \(never cuddle decl\)`
+	// want +5 `missing whitespace above this line \(never cuddle decl\)`
+	var (
+		a = 1
+		b = 2
+	)
+
+	var c = 3 // test
+
+	var (
+		d = 4
+		e = 5
+	)
 }

--- a/testdata/src/default_config/decl/decl.go.golden
+++ b/testdata/src/default_config/decl/decl.go.golden
@@ -89,3 +89,19 @@ func fn6() {
 		e = 5
 	)
 }
+
+func fn7() {
+	// want +2 `missing whitespace above this line \(never cuddle decl\)`
+	var (
+		a = 1
+		b = 2
+	)
+
+	var c = 3
+
+	// want +2 `missing whitespace above this line \(never cuddle decl\)`
+	var (
+		d = 4
+		e = 5
+	)
+}

--- a/testdata/src/default_config/decl/decl.go.golden
+++ b/testdata/src/default_config/decl/decl.go.golden
@@ -110,8 +110,8 @@ func fn8() {
  	// want +3 `missing whitespace above this line \(never cuddle decl\)`
 	// Comment above
 	var (
-	    g = 7
-	    h = 8
+		g = 7
+		h = 8
 	)
 	// Comment after
 }
@@ -124,4 +124,20 @@ func fn9() {
 	type S2 struct { // want `missing whitespace above this line \(never cuddle decl\)`
 		N int
 	}
+}
+
+func fn10() {
+ 	// want +5 `missing whitespace above this line \(never cuddle decl\)`
+ 	// want +5 `missing whitespace above this line \(never cuddle decl\)`
+ 	// want +5 `missing whitespace above this line \(never cuddle decl\)`
+	a := 1
+	b := 2
+
+	var (
+		c int
+		d        = "string"
+		e string = "string"
+	)
+
+	f := 3 // want `missing whitespace above this line \(invalid statement above assign\)`
 }

--- a/testdata/src/default_config/decl/decl.go.golden
+++ b/testdata/src/default_config/decl/decl.go.golden
@@ -105,3 +105,13 @@ func fn7() {
 		e = 5
 	)
 }
+
+func fn8() {
+ 	// want +3 `missing whitespace above this line \(never cuddle decl\)`
+	// Comment above
+	var (
+	    g = 7
+	    h = 8
+	)
+	// Comment after
+}

--- a/testdata/src/default_config/decl/decl.go.golden
+++ b/testdata/src/default_config/decl/decl.go.golden
@@ -158,7 +158,7 @@ func fn12() {
  	// want +2 `missing whitespace above this line \(never cuddle decl\)`
 	var a int
 
-	var b int // Split by comma
+	var b int // Not grouped due to this comment
 	if b > 0 {
 		_ = 1
 	}

--- a/wsl.go
+++ b/wsl.go
@@ -939,6 +939,9 @@ func (w *WSL) maybeGroupDecl(stmt *ast.DeclStmt, cursor *Cursor) bool {
 		}
 
 		for _, spec := range genDecl.Specs {
+			// We only care about value specs and not type specs or import
+			// specs. We will never see any import specs but type specs we just
+			// separate with an empty line as usual.
 			valueSpec, ok := spec.(*ast.ValueSpec)
 			if !ok {
 				return nil

--- a/wsl.go
+++ b/wsl.go
@@ -1158,6 +1158,9 @@ func asGenDeclWithValueSpecs(n ast.Node) *ast.GenDecl {
 			return nil
 		}
 
+		// It's very hard to get comments right in the ast and with the current
+		// way the ast package works we simply don't support grouping at all if
+		// there are any comments related to the node.
 		if valueSpec.Doc != nil || valueSpec.Comment != nil {
 			return nil
 		}


### PR DESCRIPTION
New tracking issue for #121 after #122 but now with the v5 codebase. 

First iteration bails out if we have any comments but as long as no comments are related to statement we can group them safely.

- [x] Group any decl statement without comments
- [ ] ~~Group any decl statement with comments~~
