### PR TITLE
Improve `err` checking, ensure working isolated

### DIFF
--- a/testdata/src/default_config/err/err.go
+++ b/testdata/src/default_config/err/err.go
@@ -1,10 +1,10 @@
-
 package testpkg
 
 import "errors"
 
 func fn1() {
 	err := errors.New("x") // want +1 `unnecessary whitespace \(err\)`
+
 	if err != nil {
 		panic(err)
 	}
@@ -12,6 +12,7 @@ func fn1() {
 
 func fn11() { // want +2 `unnecessary whitespace \(err\)`
 	err := errors.New("x")
+
 	if err != nil {
 		panic(err)
 	}
@@ -36,8 +37,8 @@ func fn13() {
 
 func fn2() {
 	a := 1
-
 	err := errors.New("x") // want +1 `unnecessary whitespace \(err\)`
+
 	if err != nil {
 		panic(err)
 	}
@@ -47,8 +48,8 @@ func fn2() {
 
 func fn21() {
 	a := 1 // want +2 `unnecessary whitespace \(err\)`
-
 	err := errors.New("x")
+
 	if err != nil {
 		panic(err)
 	}
@@ -58,7 +59,6 @@ func fn21() {
 
 func fn3() {
 	a := 1
-
 	err := errors.New("x") // want `missing whitespace above this line \(too many statements above if\)`
 	if err != nil {
 		panic(err)
@@ -70,6 +70,42 @@ func fn3() {
 func fn4() {
 	msg := "not an error"
 	err := &msg
+
+	if err != nil {
+		panic(err)
+	}
+}
+
+func fn5() {
+	err := errors.New("x") // want +1 `unnecessary whitespace \(err\)`
+
+	if err != nil {
+		panic(err)
+	}
+
+	if false {
+		_ = 1
+	}
+}
+
+func fn6() {
+	err := errors.New("x")
+
+	if false {
+		panic(err)
+	}
+}
+
+func fn7() {
+	err, ok := errors.New("x"), true
+
+	if !ok {
+		panic(err)
+	}
+}
+
+func fn8() {
+	var err = errors.New("x") // want +1 `unnecessary whitespace \(err\)`
 
 	if err != nil {
 		panic(err)

--- a/testdata/src/default_config/err/err.go.golden
+++ b/testdata/src/default_config/err/err.go.golden
@@ -4,7 +4,6 @@ import "errors"
 
 func fn1() {
 	err := errors.New("x") // want +1 `unnecessary whitespace \(err\)`
-
 	if err != nil {
 		panic(err)
 	}
@@ -12,7 +11,6 @@ func fn1() {
 
 func fn11() { // want +2 `unnecessary whitespace \(err\)`
 	err := errors.New("x")
-
 	if err != nil {
 		panic(err)
 	}
@@ -37,8 +35,8 @@ func fn13() {
 
 func fn2() {
 	a := 1
-	err := errors.New("x") // want +1 `unnecessary whitespace \(err\)`
 
+	err := errors.New("x") // want +1 `unnecessary whitespace \(err\)`
 	if err != nil {
 		panic(err)
 	}
@@ -48,8 +46,8 @@ func fn2() {
 
 func fn21() {
 	a := 1 // want +2 `unnecessary whitespace \(err\)`
-	err := errors.New("x")
 
+	err := errors.New("x")
 	if err != nil {
 		panic(err)
 	}
@@ -59,6 +57,7 @@ func fn21() {
 
 func fn3() {
 	a := 1
+
 	err := errors.New("x") // want `missing whitespace above this line \(too many statements above if\)`
 	if err != nil {
 		panic(err)
@@ -71,6 +70,40 @@ func fn4() {
 	msg := "not an error"
 	err := &msg
 
+	if err != nil {
+		panic(err)
+	}
+}
+
+func fn5() {
+	err := errors.New("x") // want +1 `unnecessary whitespace \(err\)`
+	if err != nil {
+		panic(err)
+	}
+
+	if false {
+		_ = 1
+	}
+}
+
+func fn6() {
+	err := errors.New("x")
+
+	if false {
+		panic(err)
+	}
+}
+
+func fn7() {
+	err, ok := errors.New("x"), true
+
+	if !ok {
+		panic(err)
+	}
+}
+
+func fn8() {
+	var err = errors.New("x") // want +1 `unnecessary whitespace \(err\)`
 	if err != nil {
 		panic(err)
 	}

--- a/wsl_test.go
+++ b/wsl_test.go
@@ -39,12 +39,6 @@ func TestWithConfig(t *testing.T) {
 		configFn func(*Configuration)
 	}{
 		{
-			subdir: "if_errcheck",
-			configFn: func(config *Configuration) {
-				config.Checks.Add(CheckErr)
-			},
-		},
-		{
 			subdir: "no_check_decl",
 			configFn: func(config *Configuration) {
 				config.Checks.Remove(CheckDecl)


### PR DESCRIPTION
- Always run `err` checking even if `if` is disabled
- Don't force cuddling if no errors are checked
- Don't force cuddling if no variables intersect
- Only check cuddling if previous node is assign or decl
- Move test to default testing

Closes #177 