### PR TITLE
Make error checking more laxed

### DIFF
--- a/testdata/src/default_config/err/err.go
+++ b/testdata/src/default_config/err/err.go
@@ -8,6 +8,12 @@ func fn1() {
 	if err != nil {
 		panic(err)
 	}
+
+	err2 := errors.New("y") // want +1 `unnecessary whitespace \(err\)`
+
+	if err2 == nil {
+		panic(err)
+	}
 }
 
 func fn11() { // want +2 `unnecessary whitespace \(err\)`
@@ -105,9 +111,10 @@ func fn7() {
 }
 
 func fn8() {
-	var err = errors.New("x") // want +1 `unnecessary whitespace \(err\)`
+	aErr := errors.New("a")
+	bErr := errors.New("b")
 
-	if err != nil {
-		panic(err)
+	if aErr != nil && bErr != nil {
+		panic(aErr)
 	}
 }

--- a/testdata/src/default_config/err/err.go.golden
+++ b/testdata/src/default_config/err/err.go.golden
@@ -7,6 +7,11 @@ func fn1() {
 	if err != nil {
 		panic(err)
 	}
+
+	err2 := errors.New("y") // want +1 `unnecessary whitespace \(err\)`
+	if err2 == nil {
+		panic(err)
+	}
 }
 
 func fn11() { // want +2 `unnecessary whitespace \(err\)`
@@ -103,8 +108,10 @@ func fn7() {
 }
 
 func fn8() {
-	var err = errors.New("x") // want +1 `unnecessary whitespace \(err\)`
-	if err != nil {
-		panic(err)
+	aErr := errors.New("a")
+	bErr := errors.New("b")
+
+	if aErr != nil && bErr != nil {
+		panic(aErr)
 	}
 }


### PR DESCRIPTION
Only perform error checking when there's a single comparison with a binary operator comparing an error with `nil`. Both `!=` and `==` are candidates for cuddling.

These should be cuddled if `err` exist on the line above

```go
if err != nil {}

if err == nil {}
```

Nothing else should trigger this lint, all of these should be left

```go
// More than error checking
if err != nil || true {}

// Technically an error checking, but we only check for binary
// operators, not expressions.
if errors.Is(err, SomeErr) {}

// More than one error checking
if err != nil || err2 != nil {}
```

This also matches [`gofumpt`](https://github.com/mvdan/gofumpt) which has this rule:

> No empty lines before a simple error check
>
> ```go
> foo, err := processFoo()
>
> if err != nil {
> 	return err
> }
> ```
>
> ```go
> foo, err := processFoo()
> if err != nil {
> 	return err
> }
> ```

Solves #183 