### PR TITLE
Traverse all possible subexpressions

### DIFF
--- a/testdata/src/default_config/whitespace/leading_whitespace.go
+++ b/testdata/src/default_config/whitespace/leading_whitespace.go
@@ -179,3 +179,42 @@ func fn11() {
 
 	_ = t
 }
+
+func fn12() {
+	// Assorted weird anonymous functions inside subexpressions,
+	// unlikely to be encountered in practice.
+
+	// parenthesized expression
+	_ = (func() bool { // want +1 `unnecessary whitespace \(leading-whitespace\)`
+
+		return true
+	})
+
+	// binary op
+	_ = 1 + func() int { // want +1 `unnecessary whitespace \(leading-whitespace\)`
+
+		return 123
+	}()
+
+	// type assertion expression
+	_ = func() interface{} { // want +1 `unnecessary whitespace \(leading-whitespace\)`
+
+		return 2
+	}().(int)
+
+	// test for proper FuncType traversal in type assertion below
+	var f any = func() { // want +1 `unnecessary whitespace \(leading-whitespace\)`
+
+		panic("TODO")
+	}
+
+	_ = f.(func())
+
+	var arr [10]byte
+
+	// slice expression
+	_ = b[func() int { // want +1 `unnecessary whitespace \(leading-whitespace\)`
+
+		return 5
+	}()]
+}

--- a/testdata/src/default_config/whitespace/leading_whitespace.go.golden
+++ b/testdata/src/default_config/whitespace/leading_whitespace.go.golden
@@ -156,3 +156,37 @@ func fn11() {
 
 	_ = t
 }
+
+func fn12() {
+	// Assorted weird anonymous functions inside subexpressions,
+	// unlikely to be encountered in practice.
+
+	// parenthesized expression
+	_ = (func() bool { // want +1 `unnecessary whitespace \(leading-whitespace\)`
+		return true
+	})
+
+	// binary op
+	_ = 1 + func() int { // want +1 `unnecessary whitespace \(leading-whitespace\)`
+		return 123
+	}()
+
+	// type assertion expression
+	_ = func() interface{} { // want +1 `unnecessary whitespace \(leading-whitespace\)`
+		return 2
+	}().(int)
+
+	// test for proper FuncType traversal in type assertion below
+	var f any = func() { // want +1 `unnecessary whitespace \(leading-whitespace\)`
+		panic("TODO")
+	}
+
+	_ = f.(func())
+
+	var arr [10]byte
+
+	// slice expression
+	_ = b[func() int { // want +1 `unnecessary whitespace \(leading-whitespace\)`
+	    return 5
+	}()]
+}

--- a/wsl.go
+++ b/wsl.go
@@ -128,11 +128,12 @@ func (w *WSL) checkStmt(stmt ast.Stmt, cursor *Cursor) {
 
 //nolint:unparam // False positive on `cursor`
 func (w *WSL) checkExpr(expr ast.Expr, cursor *Cursor) {
+	// This switch traverses all possible subexpressions in search
+	// of anonymous functions, no matter how unlikely or perhaps even
+	// semantically impossible it is.
 	switch s := expr.(type) {
-	// func() {}
 	case *ast.FuncLit:
 		w.checkBlock(s.Body)
-	// Call(args...)
 	case *ast.CallExpr:
 		w.checkExpr(s.Fun, cursor)
 
@@ -142,27 +143,79 @@ func (w *WSL) checkExpr(expr ast.Expr, cursor *Cursor) {
 	case *ast.StarExpr:
 		w.checkExpr(s.X, cursor)
 	case *ast.CompositeLit:
+		w.checkExpr(s.Type, cursor)
+
 		for _, e := range s.Elts {
 			w.checkExpr(e, cursor)
 		}
-	// Key: Value, e.g. in T{Key: Value}
 	case *ast.KeyValueExpr:
+		w.checkExpr(s.Key, cursor)
 		w.checkExpr(s.Value, cursor)
-	case *ast.ArrayType,
-		*ast.BasicLit,
-		*ast.BinaryExpr,
-		*ast.ChanType,
-		*ast.Ellipsis,
-		*ast.Ident,
-		*ast.IndexExpr,
-		*ast.IndexListExpr,
-		*ast.MapType,
-		*ast.ParenExpr,
-		*ast.SelectorExpr,
-		*ast.SliceExpr,
-		*ast.TypeAssertExpr,
-		*ast.UnaryExpr,
-		nil:
+	case *ast.ArrayType:
+		w.checkExpr(s.Elt, cursor)
+		w.checkExpr(s.Len, cursor)
+	case *ast.BasicLit:
+	case *ast.BinaryExpr:
+		w.checkExpr(s.X, cursor)
+		w.checkExpr(s.Y, cursor)
+	case *ast.ChanType:
+		w.checkExpr(s.Value, cursor)
+	case *ast.Ellipsis:
+		w.checkExpr(s.Elt, cursor)
+	case *ast.FuncType:
+		if params := s.TypeParams; params != nil {
+			for _, f := range params.List {
+				w.checkExpr(f.Type, cursor)
+			}
+		}
+
+		if params := s.Params; params != nil {
+			for _, f := range params.List {
+				w.checkExpr(f.Type, cursor)
+			}
+		}
+
+		if results := s.Results; results != nil {
+			for _, f := range results.List {
+				w.checkExpr(f.Type, cursor)
+			}
+		}
+	case *ast.Ident:
+	case *ast.IndexExpr:
+		w.checkExpr(s.Index, cursor)
+		w.checkExpr(s.X, cursor)
+	case *ast.IndexListExpr:
+		w.checkExpr(s.X, cursor)
+
+		for _, e := range s.Indices {
+			w.checkExpr(e, cursor)
+		}
+	case *ast.InterfaceType:
+		for _, f := range s.Methods.List {
+			w.checkExpr(f.Type, cursor)
+		}
+	case *ast.MapType:
+		w.checkExpr(s.Key, cursor)
+		w.checkExpr(s.Value, cursor)
+	case *ast.ParenExpr:
+		w.checkExpr(s.X, cursor)
+	case *ast.SelectorExpr:
+		w.checkExpr(s.X, cursor)
+	case *ast.SliceExpr:
+		w.checkExpr(s.X, cursor)
+		w.checkExpr(s.Low, cursor)
+		w.checkExpr(s.High, cursor)
+		w.checkExpr(s.Max, cursor)
+	case *ast.StructType:
+		for _, f := range s.Fields.List {
+			w.checkExpr(f.Type, cursor)
+		}
+	case *ast.TypeAssertExpr:
+		w.checkExpr(s.X, cursor)
+		w.checkExpr(s.Type, cursor)
+	case *ast.UnaryExpr:
+		w.checkExpr(s.X, cursor)
+	case nil:
 	default:
 	}
 }


### PR DESCRIPTION
Although functions inside struct literals have been fixed recently, this switch still missed a couple of cases.

Instead of weighing cases how unlikely they are, just blindly traverse every possible subexpressions.

The included tests do indeed highlight how ridiculous some of the cases are. I didn't bother covering all the cases.

Closes #191