### PR TITLE
Ignore idents for constants, types, packages and nil

### DIFF
--- a/testdata/src/default_config/type_names/type_names.go
+++ b/testdata/src/default_config/type_names/type_names.go
@@ -1,0 +1,27 @@
+package testpkg
+
+import "fmt"
+
+func dontMatchTypeNames() {
+	var z string
+	defer func(x string) { // want `missing whitespace above this line \(no shared variables above defer\)`
+		fmt.Printf("%v", x)
+	}("")
+
+	var a any = nil
+	defer func(x any) { // want `missing whitespace above this line \(no shared variables above defer\)`
+		fmt.Printf("%v", x)
+	}(nil)
+
+	b := true
+	defer func(x any) { // want `missing whitespace above this line \(no shared variables above defer\)`
+		fmt.Printf("%v", x)
+	}(true)
+
+	c := false
+	defer func(x any) { // want `missing whitespace above this line \(no shared variables above defer\)`
+		fmt.Printf("%v", x)
+	}(false)
+
+	_, _, _, _ = a, b, c, z
+}

--- a/testdata/src/default_config/type_names/type_names.go.golden
+++ b/testdata/src/default_config/type_names/type_names.go.golden
@@ -1,0 +1,32 @@
+package testpkg
+
+import "fmt"
+
+func dontMatchTypeNames() {
+	var z string
+
+	defer func(x string) { // want `missing whitespace above this line \(no shared variables above defer\)`
+		fmt.Printf("%v", x)
+	}("")
+
+	var a any = nil
+
+	defer func(x any) { // want `missing whitespace above this line \(no shared variables above defer\)`
+		fmt.Printf("%v", x)
+	}(nil)
+
+	b := true
+
+	defer func(x any) { // want `missing whitespace above this line \(no shared variables above defer\)`
+		fmt.Printf("%v", x)
+	}(true)
+
+	c := false
+
+	defer func(x any) { // want `missing whitespace above this line \(no shared variables above defer\)`
+		fmt.Printf("%v", x)
+	}(false)
+
+	_, _, _, _ = a, b, c, z
+}
+

--- a/wsl.go
+++ b/wsl.go
@@ -655,6 +655,7 @@ func (w *WSL) checkError(
 	}
 
 	previousIdents := []*ast.Ident{}
+
 	if assign, ok := previousNode.(*ast.AssignStmt); ok {
 		for _, lhs := range assign.Lhs {
 			previousIdents = append(previousIdents, w.identsFromNode(lhs, true)...)

--- a/wsl.go
+++ b/wsl.go
@@ -292,7 +292,7 @@ func (w *WSL) checkCuddlingMaxAllowed(
 	}
 
 	numStmtsAbove := w.numberOfStatementsAbove(cursor)
-	previousIdents := identsFromNode(previousNode, true)
+	previousIdents := w.identsFromNode(previousNode, true)
 
 	// If we don't have any statements above, we only care about potential error
 	// cuddling (for if statements) so check that.
@@ -335,7 +335,7 @@ func (w *WSL) checkCuddlingMaxAllowed(
 	// FEATURE(AllowWholeBlock): Allow identifier used anywhere in block
 	// (including recursive blocks).
 	if w.config.AllowWholeBlock {
-		allIdentsInBlock := identsFromNode(stmt, false)
+		allIdentsInBlock := w.identsFromNode(stmt, false)
 		if checkIntersection(allIdentsInBlock) {
 			return
 		}
@@ -343,13 +343,13 @@ func (w *WSL) checkCuddlingMaxAllowed(
 
 	// FEATURE(AllowFirstInBlock): Allow identifiers used first in block.
 	if !w.config.AllowWholeBlock && w.config.AllowFirstInBlock {
-		firstStmtIdents := identsFromNode(firstBlockStmt, true)
+		firstStmtIdents := w.identsFromNode(firstBlockStmt, true)
 		if checkIntersection(firstStmtIdents) {
 			return
 		}
 	}
 
-	currentIdents := identsFromNode(stmt, true)
+	currentIdents := w.identsFromNode(stmt, true)
 	if checkIntersection(currentIdents) {
 		return
 	}
@@ -412,7 +412,7 @@ func (w *WSL) checkCuddlingWithoutIntersection(stmt ast.Node, cursor *Cursor) {
 	prevIsValidType := previousNode == nil || prevIsAssign || prevIsDecl || prevIsIncDec
 
 	if _, ok := w.config.Checks[CheckAssignExpr]; !ok {
-		if _, ok := previousNode.(*ast.ExprStmt); ok && hasIntersection(stmt, previousNode) {
+		if _, ok := previousNode.(*ast.ExprStmt); ok && w.hasIntersection(stmt, previousNode) {
 			prevIsValidType = prevIsValidType || ok
 		}
 	}
@@ -506,7 +506,7 @@ func (w *WSL) checkAppend(stmt *ast.AssignStmt, cursor *Cursor) {
 		return
 	}
 
-	if !hasIntersection(appendNode, previousNode) {
+	if !w.hasIntersection(appendNode, previousNode) {
 		w.addErrorNoIntersection(stmt.Pos(), CheckAppend)
 	}
 }
@@ -577,7 +577,7 @@ func (w *WSL) checkDefer(stmt *ast.DeferStmt, cursor *Cursor) {
 				cursor.Previous()
 				cursor.Previous()
 
-				if hasIntersection(cursor.Stmt(), stmt) {
+				if w.hasIntersection(cursor.Stmt(), stmt) {
 					return 1, false
 				}
 			}
@@ -657,7 +657,7 @@ func (w *WSL) checkError(
 	previousIdents := []*ast.Ident{}
 	if assign, ok := previousNode.(*ast.AssignStmt); ok {
 		for _, lhs := range assign.Lhs {
-			previousIdents = append(previousIdents, identsFromNode(lhs, true)...)
+			previousIdents = append(previousIdents, w.identsFromNode(lhs, true)...)
 		}
 	}
 
@@ -1154,7 +1154,7 @@ func (w *WSL) maybeCheckBlock(
 		if check != CheckSwitch && check != CheckTypeSwitch && check != CheckSelect {
 			blockList = blockStmt.List
 		} else {
-			allowedIdents = identsFromCaseArms(node)
+			allowedIdents = w.identsFromCaseArms(node)
 		}
 
 		w.checkCuddlingBlock(node, blockList, allowedIdents, cursor, 1)
@@ -1302,13 +1302,13 @@ func asGenDeclWithValueSpecs(n ast.Node) *ast.GenDecl {
 	return genDecl
 }
 
-func hasIntersection(a, b ast.Node) bool {
-	return len(nodeIdentIntersection(a, b)) > 0
+func (w *WSL) hasIntersection(a, b ast.Node) bool {
+	return len(w.nodeIdentIntersection(a, b)) > 0
 }
 
-func nodeIdentIntersection(a, b ast.Node) []*ast.Ident {
-	aI := identsFromNode(a, true)
-	bI := identsFromNode(b, true)
+func (w *WSL) nodeIdentIntersection(a, b ast.Node) []*ast.Ident {
+	aI := w.identsFromNode(a, true)
+	bI := w.identsFromNode(b, true)
 
 	return identIntersection(aI, bI)
 }
@@ -1327,7 +1327,31 @@ func identIntersection(a, b []*ast.Ident) []*ast.Ident {
 	return intersects
 }
 
-func identsFromNode(node ast.Node, skipBlock bool) []*ast.Ident {
+func isTypeOrPredeclConst(obj types.Object) bool {
+	switch o := obj.(type) {
+	case *types.TypeName:
+		// Covers predeclared types ("string", "int", ...) and user types.
+		return true
+	case *types.Const:
+		// true/false/iota are universe consts.
+		return o.Parent() == types.Universe
+	case *types.Nil:
+		return true
+	case *types.PkgName:
+		// Skip package qualifiers like "fmt" in fmt.Println
+		return true
+	default:
+		return false
+	}
+}
+
+// identsFromNode returns all *ast.Ident in a node except:
+//   - type names (types.TypeName)
+//   - builtin constants from the universe (true, false, iota)
+//   - nil (*types.Nil)
+//   - package names (types.PkgName)
+//   - the blank identifier "_"
+func (w *WSL) identsFromNode(node ast.Node, skipBlock bool) []*ast.Ident {
 	var (
 		idents []*ast.Ident
 		seen   = map[string]struct{}{}
@@ -1337,6 +1361,24 @@ func identsFromNode(node ast.Node, skipBlock bool) []*ast.Ident {
 		return idents
 	}
 
+	addIdent := func(ident *ast.Ident) {
+		if ident == nil {
+			return
+		}
+
+		name := ident.Name
+		if name == "" || name == "_" {
+			return
+		}
+
+		if _, ok := seen[name]; ok {
+			return
+		}
+
+		idents = append(idents, ident)
+		seen[name] = struct{}{}
+	}
+
 	ast.Inspect(node, func(n ast.Node) bool {
 		if skipBlock {
 			if _, ok := n.(*ast.BlockStmt); ok {
@@ -1344,12 +1386,30 @@ func identsFromNode(node ast.Node, skipBlock bool) []*ast.Ident {
 			}
 		}
 
-		if ident, ok := n.(*ast.Ident); ok {
-			if _, exists := seen[ident.Name]; !exists {
-				idents = append(idents, ident)
-				seen[ident.Name] = struct{}{}
-			}
+		ident, ok := n.(*ast.Ident)
+		if !ok {
+			return true
 		}
+
+		// Prefer Uses over Defs; fall back to Defs if not a use site.
+		var typesObject types.Object
+		if obj := w.typeInfo.Uses[ident]; obj != nil {
+			typesObject = obj
+		} else if obj := w.typeInfo.Defs[ident]; obj != nil {
+			typesObject = obj
+		}
+
+		// Unresolved (could be a build-tag or syntax artifact). Keep it.
+		if typesObject == nil {
+			addIdent(ident)
+			return true
+		}
+
+		if isTypeOrPredeclConst(typesObject) {
+			return true
+		}
+
+		addIdent(ident)
 
 		return true
 	})
@@ -1357,14 +1417,14 @@ func identsFromNode(node ast.Node, skipBlock bool) []*ast.Ident {
 	return idents
 }
 
-func identsFromCaseArms(node ast.Node) []*ast.Ident {
+func (w *WSL) identsFromCaseArms(node ast.Node) []*ast.Ident {
 	var (
 		idents []*ast.Ident
 		nodes  []ast.Stmt
 		seen   = map[string]struct{}{}
 
 		addUnseen = func(node ast.Node) {
-			for _, ident := range identsFromNode(node, true) {
+			for _, ident := range w.identsFromNode(node, true) {
 				if _, ok := seen[ident.Name]; ok {
 					continue
 				}


### PR DESCRIPTION
There are a lot of nodes that holds an `*ast.Ident` that's not a name that's declared by the user in the code. This can be things like constants such as `true` or `false`, or just a type name such as `string` in the statement `var a string`.

We never want to treat them as idents when looking for intersection because they're not related to the code written by the user.

In this example:

```go
var z string
defer func(x string) {}("")
```

There are no intersections, only `z` on 1st line and `x` on 2nd line, but faulty identifying `string` on both lines result in a false negative where a non existing intersection is found.

We now make use of the types info we get from the analysis pass and ignore type names, constants, nil and package names.

Fixes #199