### PR TITLE
Fix decl grouping collapsing multiline composite literals

### DIFF
--- a/testdata/src/default_config/decl/decl.go
+++ b/testdata/src/default_config/decl/decl.go
@@ -212,3 +212,29 @@ func fn17() {
 
 	_, _ = a, b
 }
+
+func fn18() {
+	// want +5 `missing whitespace above this line \(never cuddle decl\)`
+	var a = map[uint8]string{
+		1: "foo",
+		2: "bar",
+	}
+	var b = []struct {
+		a string
+		b int
+		c bool
+	}{
+		{
+			a: "string",
+			b: "int",
+			c: true,
+		},
+		{
+			a: "string",
+			b: "int",
+			c: true,
+		},
+	}
+
+	_, _ = a, b
+}

--- a/testdata/src/default_config/decl/decl.go.golden
+++ b/testdata/src/default_config/decl/decl.go.golden
@@ -247,3 +247,31 @@ func fn17() {
 
 	_, _ = a, b
 }
+
+func fn18() {
+	// want +5 `missing whitespace above this line \(never cuddle decl\)`
+	var (
+		a = map[uint8]string{
+			1: "foo",
+			2: "bar",
+		}
+		b = []struct {
+			a string
+			b int
+			c bool
+		}{
+			{
+				a: "string",
+				b: "int",
+				c: true,
+			},
+			{
+				a: "string",
+				b: "int",
+				c: true,
+			},
+		}
+	)
+
+	_, _ = a, b
+}

--- a/wsl.go
+++ b/wsl.go
@@ -1099,13 +1099,7 @@ func (w *WSL) maybeGroupDecl(stmt *ast.DeclStmt, cursor *Cursor) bool {
 		return false
 	}
 
-	group := &ast.GenDecl{
-		Tok:    firstNode.Tok,
-		Lparen: 1,
-		Specs:  firstNode.Specs,
-	}
-
-	group.Specs = append(group.Specs, currentNode.Specs...)
+	specs := slices.Concat(firstNode.Specs, currentNode.Specs)
 
 	reportNodes := []ast.Node{currentNode}
 	lastNode := currentNode
@@ -1131,15 +1125,25 @@ func (w *WSL) maybeGroupDecl(stmt *ast.DeclStmt, cursor *Cursor) bool {
 
 		cursor.Next()
 
-		group.Specs = append(group.Specs, nextNode.Specs...)
+		specs = append(specs, nextNode.Specs...)
 		reportNodes = append(reportNodes, nextNode)
 		lastNode = nextNode
 	}
 
 	var buf bytes.Buffer
-	if err := format.Node(&buf, token.NewFileSet(), group); err != nil {
-		return false
+	fmt.Fprintf(&buf, "%s (\n", firstNode.Tok)
+
+	for _, spec := range specs {
+		var specBuf bytes.Buffer
+		if err := format.Node(&specBuf, w.fset, spec); err != nil {
+			return false
+		}
+
+		buf.Write(specBuf.Bytes())
+		buf.WriteByte('\n')
 	}
+
+	buf.WriteByte(')')
 
 	// We add a diagnostic to every subsequent statement to properly represent
 	// the violations. Duplicate fixes for the same range is fine.


### PR DESCRIPTION
Format each spec individually with the original FileSet to preserve multiline structure in complex types (maps, structs), then assemble the grouped declaration manually.

Fixes #248 