### PR TITLE
Add `expr-cuddle` check

### DIFF
--- a/CHECKS.md
+++ b/CHECKS.md
@@ -18,6 +18,7 @@
   - [`defer`](#defer)
   - [`err`](#err)
   - [`expr`](#expr)
+  - [`expr-cuddle`](#expr-cuddle)
   - [`for`](#for)
   - [`go`](#go)
   - [`if`](#if)
@@ -615,6 +616,76 @@ fmt.Println(a)
 </tbody></table>
 
 [🔝](#table-of-content)
+
+### `expr-cuddle`
+
+By default, expression statements (e.g. function calls with side effects) are
+not allowed to be cuddled immediately above block statements (`if`, `for`,
+`switch`, `range`, `select`, `type-switch`, `go`, `defer`). Disabling this
+check permits such cuddling when the expression shares at least one variable
+with the following statement.
+
+> [!NOTE]
+> The linter can only check for shared variable *names*, not whether the
+> expression actually modifies the variable. A call like `fmt.Println(x)`
+> would be permitted above `if x > 0` even though it has no side effect on
+> `x`. This is an accepted trade-off when opting in by disabling the check.
+
+> [!NOTE]
+> This check is the counterpart to [`assign-expr`](#assign-expr), which
+> controls whether expressions may be cuddled above *assignments*. The two
+> can be combined.
+
+<table>
+<thead><tr><th>Bad (default, check enabled)</th><th>Good (check disabled)</th></tr></thead>
+<tbody>
+<tr><td valign="top">
+
+```go
+// item.setKey modifies srcItem, which is used in the
+// if condition — but the check still rejects this.
+item.setKey(&srcItem, dstKey) // 1
+if err := src.Update(ctx, srcItem); err != nil {
+    return err
+}
+
+someArg := "hello"
+log.Printf("initialized: %s", someArg) // 2
+if a < b {
+    someArg = "world"
+}
+```
+
+</td><td valign="top">
+
+```go
+// With expr-cuddle disabled, shared variables are
+// enough to permit the cuddle.
+item.setKey(&srcItem, dstKey)
+if err := src.Update(ctx, srcItem); err != nil {
+    return err
+}
+
+someArg := "hello"
+log.Printf("initialized: %s", someArg)
+if a < b {
+    someArg = "world"
+}
+```
+
+</td></tr>
+
+<tr><td valign="top">
+
+<sup>1</sup> Expression statement above `if` (no shared variable check needed,
+type itself is disallowed)
+
+<sup>2</sup> Expression statement above `if`
+
+</td><td valign="top">
+
+</td></tr>
+</tbody></table>
 
 ### `for`
 
@@ -1987,6 +2058,13 @@ Setting it to `0` disallows any cuddling, the trigger always requires a blank
 line above it, even when the variable on the line above is used by the block.
 The recommended way to allow any number of statements is to set a really high
 number such as `9999`.
+
+> [!NOTE]
+> By default, only assignments, declarations, and increment/decrement
+> statements are valid predecessors. Disabling [`expr-cuddle`](#expr-cuddle)
+> also permits expression statements (e.g. function calls) to count as valid
+> cuddled predecessors, subject to the same limit and intersection
+> requirements.
 
 <table>
 <thead><tr><th>Bad</th><th>Good</th></tr></thead>

--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ For more details and examples, see [CHECKS](CHECKS.md).
   e.g. function calls
 - ❌ **cuddle-group** - Treat the cuddled chain as a unit; separate the whole
   group from the block instead of splitting between cuddled variables
+- ✅ **expr-cuddle** - Don't allow expression statements (e.g. function calls)
+  to be cuddled above block statements (`if`, `for`, `switch`, `go`, `defer`,
+  etc.). Disable to permit cuddling when the expression shares a variable with
+  the following statement
 - ✅ **err** - Error checking must follow immediately after the error variable
   is assigned
 - ✅ **leading-whitespace** - Disallow leading empty lines in blocks
@@ -165,6 +169,7 @@ linters:
         - defer
         - err
         - expr
+        - expr-cuddle
         - for
         - go
         - if

--- a/analyzer_test.go
+++ b/analyzer_test.go
@@ -181,6 +181,18 @@ func TestWithConfig(t *testing.T) {
 				config.CuddleMaxStatements = 2
 			},
 		},
+		{
+			subdir: "expr_cuddle",
+			configFn: func(config *Configuration) {
+				config.CuddleMaxStatements = 9999
+
+				config.Checks = NoChecks()
+				config.Checks.Add(CheckIf)
+				config.Checks.Add(CheckFor)
+				config.Checks.Add(CheckGo)
+				config.Checks.Add(CheckDefer)
+			},
+		},
 	} {
 		t.Run(tc.subdir, func(t *testing.T) {
 			t.Parallel()

--- a/config.go
+++ b/config.go
@@ -88,6 +88,14 @@ const (
 	// if a > b {}
 	// .
 	CheckCuddleGroup
+	// CheckExprCuddle will check that expression statements are not cuddled
+	// with other statements. Disable this check to allow expression statements
+	// to be cuddled above any statement when they share variables, e.g.
+	//
+	// s.setKey(&item, key)
+	// if err := src.Update(ctx, item); err != nil {
+	// .
+	CheckExprCuddle
 	// CheckErr force error checking to follow immediately after an error
 	// variable is assigned, e.g.
 	//
@@ -134,6 +142,7 @@ func (c CheckType) String() string {
 		"assign-exclusive",
 		"assign-expr",
 		"cuddle-group",
+		"expr-cuddle",
 		"err",
 		"leading-whitespace",
 		"trailing-whitespace",
@@ -228,6 +237,7 @@ func DefaultChecks() CheckSet {
 		CheckDefer:              {},
 		CheckErr:                {},
 		CheckExpr:               {},
+		CheckExprCuddle:         {},
 		CheckFor:                {},
 		CheckGo:                 {},
 		CheckIf:                 {},
@@ -321,6 +331,8 @@ func CheckFromString(s string) (CheckType, error) {
 		return CheckAssignExclusive, nil
 	case "assign-expr":
 		return CheckAssignExpr, nil
+	case "expr-cuddle":
+		return CheckExprCuddle, nil
 	case "err":
 		return CheckErr, nil
 	case "cuddle-group":

--- a/config_test.go
+++ b/config_test.go
@@ -83,7 +83,7 @@ func TestCheckSet(t *testing.T) {
 func TestToAndFromString(t *testing.T) {
 	t.Parallel()
 
-	maxCheckNumber := 29
+	maxCheckNumber := 30
 
 	for n := range maxCheckNumber {
 		check := CheckType(n)

--- a/testdata/src/with_config/expr_cuddle/expr_cuddle.go
+++ b/testdata/src/with_config/expr_cuddle/expr_cuddle.go
@@ -1,0 +1,75 @@
+package testpkg
+
+import "fmt"
+
+type item struct {
+	key string
+}
+
+func (i *item) setKey(k string) {
+	i.key = k
+}
+
+// ifWithIntersection: expr stmt sharing a variable with if — allowed.
+func ifWithIntersection(i *item) {
+	i.setKey("hello")
+	if i.key == "hello" {
+		fmt.Println("match")
+	}
+}
+
+// ifWithoutIntersection: expr stmt not sharing a variable with if — still reported.
+func ifWithoutIntersection(a int, b int) {
+	fmt.Println(b)
+	if a > 0 { // want `missing whitespace above this line \(no shared variables above if\)`
+		_ = a
+	}
+}
+
+// forWithIntersection: expr stmt sharing a variable with for — allowed.
+func forWithIntersection(items []item, key string) {
+	items[0].setKey(key)
+	for _, it := range items {
+		fmt.Println(it.key)
+	}
+}
+
+// goWithIntersection: expr stmt sharing a variable with go — allowed.
+func goWithIntersection(i *item) {
+	i.setKey("async")
+	go fmt.Println(i.key)
+}
+
+// deferWithIntersection: expr stmt sharing a variable with defer — allowed.
+func deferWithIntersection(i *item) {
+	i.setKey("deferred")
+	defer fmt.Println(i.key)
+}
+
+func nestedExprBeforeInnerIf(i *item, key string, check bool) {
+	if check {
+		i.setKey(key)
+		if i.key == key {
+			fmt.Println("match")
+		}
+	}
+}
+
+func exprBetweenAssignAndIf(a, b int) {
+	someArg := "hello"
+	fmt.Println(someArg)
+	if a < b {
+		someArg = "world"
+		fmt.Println(someArg)
+	}
+}
+
+func mixingExpr(b, d int) {
+	a := 1
+	fmt.Println(b)
+	c := 2
+	fmt.Println(d)
+	if a+b+c+d > 0 {
+		fmt.Println("mix")
+	}
+}

--- a/testdata/src/with_config/expr_cuddle/expr_cuddle.go.golden
+++ b/testdata/src/with_config/expr_cuddle/expr_cuddle.go.golden
@@ -1,0 +1,76 @@
+package testpkg
+
+import "fmt"
+
+type item struct {
+	key string
+}
+
+func (i *item) setKey(k string) {
+	i.key = k
+}
+
+// ifWithIntersection: expr stmt sharing a variable with if — allowed.
+func ifWithIntersection(i *item) {
+	i.setKey("hello")
+	if i.key == "hello" {
+		fmt.Println("match")
+	}
+}
+
+// ifWithoutIntersection: expr stmt not sharing a variable with if — still reported.
+func ifWithoutIntersection(a int, b int) {
+	fmt.Println(b)
+
+	if a > 0 { // want `missing whitespace above this line \(no shared variables above if\)`
+		_ = a
+	}
+}
+
+// forWithIntersection: expr stmt sharing a variable with for — allowed.
+func forWithIntersection(items []item, key string) {
+	items[0].setKey(key)
+	for _, it := range items {
+		fmt.Println(it.key)
+	}
+}
+
+// goWithIntersection: expr stmt sharing a variable with go — allowed.
+func goWithIntersection(i *item) {
+	i.setKey("async")
+	go fmt.Println(i.key)
+}
+
+// deferWithIntersection: expr stmt sharing a variable with defer — allowed.
+func deferWithIntersection(i *item) {
+	i.setKey("deferred")
+	defer fmt.Println(i.key)
+}
+
+func nestedExprBeforeInnerIf(i *item, key string, check bool) {
+	if check {
+		i.setKey(key)
+		if i.key == key {
+			fmt.Println("match")
+		}
+	}
+}
+
+func exprBetweenAssignAndIf(a, b int) {
+	someArg := "hello"
+	fmt.Println(someArg)
+	if a < b {
+		someArg = "world"
+		fmt.Println(someArg)
+	}
+}
+
+func mixingExpr(b, d int) {
+	a := 1
+	fmt.Println(b)
+	c := 2
+	fmt.Println(d)
+	if a+b+c+d > 0 {
+		fmt.Println("mix")
+	}
+}

--- a/wsl.go
+++ b/wsl.go
@@ -193,9 +193,11 @@ func (w *WSL) checkCuddlingMaxAllowed(
 	_, currIsGo := stmt.(*ast.GoStmt)
 	currRelaxesPrevType := currIsDefer || currIsGo
 
-	// We're cuddled but not with an assign, declare, increment/decrement and
-	// we're not a statement with relaxed check.
-	if !isAssignDeclOrIncDec(previousNode) && !currRelaxesPrevType {
+	// We're cuddled but not with a valid predecessor and we're not a statement
+	// with relaxed check. Expression statements may pass this gate if
+	// expr-cuddle is disabled; intersection is then checked below like any
+	// other predecessor.
+	if !w.isValidCuddlePredecessor(previousNode) && !currRelaxesPrevType {
 		w.addErrorInvalidTypeCuddle(cursor.Stmt().Pos(), cursor.checkType)
 		return
 	}
@@ -320,7 +322,7 @@ func (w *WSL) countValidCuddledStatements(
 		}
 
 		prevNode := cursor.Stmt()
-		if !isAssignDeclOrIncDec(prevNode) && !allowAnyStmtType {
+		if !w.isValidCuddlePredecessor(prevNode) && !allowAnyStmtType {
 			break
 		}
 
@@ -1549,12 +1551,19 @@ func (w *WSL) addErrorWithMessageAndFix(report, start, end token.Pos, message st
 	w.issues[report] = iss
 }
 
-func isAssignDeclOrIncDec(n ast.Node) bool {
+func (w *WSL) isValidCuddlePredecessor(n ast.Node) bool {
 	_, a := n.(*ast.AssignStmt)
 	_, d := n.(*ast.DeclStmt)
 	_, i := n.(*ast.IncDecStmt)
 
-	return a || d || i
+	if a || d || i {
+		return true
+	}
+
+	_, isExpr := n.(*ast.ExprStmt)
+	_, exprCuddleEnabled := w.config.Checks[CheckExprCuddle]
+
+	return isExpr && !exprCuddleEnabled
 }
 
 func asGenDeclWithValueSpecs(n ast.Node) *ast.GenDecl {


### PR DESCRIPTION
Add explicit check for cuddling of expressions (with intersecting variables). This check is enabled by default but by switching it off it's allowed to cuddle expr everywhere assign, decl and inc/dec is allowed today.

# NOTE ⚠️

This is just a tracking PR for #244 since the change was minimal. This does **not** mean I plan to merge this any time soon. It can also be used to add some more examples on expected and unexpected results by having this check.

The test file now contains a few different variants that uses this checks but most other checks are turned off. E.g. the last test `mixingExpr` would not pass with the default setup since other checks would require splitting the expressions and assignments.