### PR TITLE
Add `after-` checks

### DIFF
--- a/CHECKS.md
+++ b/CHECKS.md
@@ -105,6 +105,8 @@ defer f.Close()
 </td></tr>
 </tbody></table>
 
+[🔝](#table-of-content)
+
 ### `after-decl`
 
 Declaration statements (`var`, `const`, `type`) should be followed by a blank
@@ -160,6 +162,8 @@ fmt.Println(a, b)
 </td></tr>
 </tbody></table>
 
+[🔝](#table-of-content)
+
 ### `after-defer`
 
 `defer` statements should be followed by a blank line. Consecutive `defer`s
@@ -207,6 +211,8 @@ doWork()
 </td></tr>
 </tbody></table>
 
+[🔝](#table-of-content)
+
 ### `after-expr`
 
 Expression statements (e.g. function calls used for their side effects) should
@@ -251,6 +257,8 @@ doWork()
 </td></tr>
 </tbody></table>
 
+[🔝](#table-of-content)
+
 ### `after-go`
 
 `go` statements should be followed by a blank line. Consecutive `go`
@@ -290,6 +298,8 @@ fmt.Println("next")
 
 </td></tr>
 </tbody></table>
+
+[🔝](#table-of-content)
 
 ### `assign`
 
@@ -345,6 +355,8 @@ c := 3
 
 </td></tr>
 </tbody></table>
+
+[🔝](#table-of-content)
 
 ### `branch`
 
@@ -403,6 +415,8 @@ for {
 
 </td></tr>
 </tbody></table>
+
+[🔝](#table-of-content)
 
 ### `decl`
 
@@ -473,6 +487,8 @@ var a string
 </td></tr>
 </tbody></table>
 
+[🔝](#table-of-content)
+
 ### `defer`
 
 Deferring execution should only be used directly in the context of what's being
@@ -538,6 +554,8 @@ defer m.Unlock()
 </td></tr>
 </tbody></table>
 
+[🔝](#table-of-content)
+
 ### `expr`
 
 Expressions can be multiple things and a big part of them are not handled by
@@ -590,6 +608,8 @@ fmt.Println(a)
 
 </td></tr>
 </tbody></table>
+
+[🔝](#table-of-content)
 
 ### `for`
 
@@ -677,6 +697,8 @@ for {
 </td></tr>
 </tbody></table>
 
+[🔝](#table-of-content)
+
 ### `go`
 
 <table>
@@ -726,6 +748,8 @@ go Fn(someArg)
 
 </td></tr>
 </tbody></table>
+
+[🔝](#table-of-content)
 
 ### `if`
 
@@ -855,6 +879,8 @@ if xUsedLaterInBlock() {
 </td></tr>
 </tbody></table>
 
+[🔝](#table-of-content)
+
 ### `inc-dec`
 
 <table>
@@ -899,6 +925,8 @@ j++
 
 </td></tr>
 </tbody></table>
+
+[🔝](#table-of-content)
 
 ### `label`
 
@@ -945,6 +973,8 @@ L2:
 
 </td></tr>
 </tbody></table>
+
+[🔝](#table-of-content)
 
 ### `range`
 
@@ -1026,6 +1056,8 @@ for _, v := range s2 {
 </td></tr>
 </tbody></table>
 
+[🔝](#table-of-content)
+
 ### `return`
 
 > [!NOTE]
@@ -1079,6 +1111,8 @@ func Fn() int {
 
 </td></tr>
 </tbody></table>
+
+[🔝](#table-of-content)
 
 ### `select`
 
@@ -1152,6 +1186,8 @@ case <-stop:
 </td></tr>
 </tbody></table>
 
+[🔝](#table-of-content)
+
 ### `send`
 
 Send statements should only be cuddled with a single variable that is used on
@@ -1193,6 +1229,8 @@ b := 1
 
 </td></tr>
 </tbody></table>
+
+[🔝](#table-of-content)
 
 ### `switch`
 
@@ -1299,6 +1337,8 @@ case 2:
 </td></tr>
 </tbody></table>
 
+[🔝](#table-of-content)
+
 ### `type-switch`
 
 > [!NOTE]
@@ -1382,6 +1422,8 @@ case int64:
 </td></tr>
 </tbody></table>
 
+[🔝](#table-of-content)
+
 ### `append`
 
 Append enables strict `append` checking where assignments that are
@@ -1429,6 +1471,8 @@ s = append(s, 2)
 </td></tr>
 </tbody></table>
 
+[🔝](#table-of-content)
+
 ### `assign-exclusive`
 
 Assign exclusive does not allow mixing new assignments (`:=`) with
@@ -1471,6 +1515,8 @@ d = 4
 </td></tr>
 </tbody></table>
 
+[🔝](#table-of-content)
+
 ### `assign-expr`
 
 Assignments are allowed to be cuddled with expressions, primarily to support
@@ -1509,6 +1555,8 @@ t1.Fn3()
 </td></tr>
 </tbody></table>
 
+[🔝](#table-of-content)
+
 ### `err`
 
 <table>
@@ -1544,6 +1592,8 @@ if err != nil {
 </td></tr>
 </tbody></table>
 
+[🔝](#table-of-content)
+
 ### `leading-whitespace`
 
 <table>
@@ -1570,6 +1620,8 @@ if true {
 
 </tbody></table>
 
+[🔝](#table-of-content)
+
 ### `trailing-whitespace`
 
 <table>
@@ -1595,6 +1647,8 @@ if true {
 </td></tr>
 
 </tbody></table>
+
+[🔝](#table-of-content)
 
 ## Configuration
 
@@ -1630,6 +1684,8 @@ if anotherVariable {
 }
 ```
 
+[🔝](#table-of-content)
+
 ### `allow-whole-block`
 
 This is similar to `allow-first-in-block` but now allows the lack of whitespace
@@ -1645,6 +1701,8 @@ if anotherVariable {
     }
 }
 ```
+
+[🔝](#table-of-content)
 
 ### `branch-max-lines`
 
@@ -1703,6 +1761,8 @@ func ShortFn() int {
 
 </td></tr>
 </tbody></table>
+
+[🔝](#table-of-content)
 
 ### `case-max-lines`
 
@@ -1827,6 +1887,8 @@ case 2:
 </td></tr>
 </tbody></table>
 
+[🔝](#table-of-content)
+
 ### `cuddle-max-statements`
 
 Controls the maximum number of consecutive statements that may be cuddled
@@ -1895,3 +1957,5 @@ if a+b+c > 0 {
 
 </td></tr>
 </tbody></table>
+
+[🔝](#table-of-content)

--- a/CHECKS.md
+++ b/CHECKS.md
@@ -4,6 +4,10 @@
 
 - [Checks](#checks)
   - [`after-block`](#after-block)
+  - [`after-decl`](#after-decl)
+  - [`after-defer`](#after-defer)
+  - [`after-expr`](#after-expr)
+  - [`after-go`](#after-go)
   - [`append`](#append)
   - [`assign`](#assign)
   - [`assign-exclusive`](#assign-exclusive)
@@ -95,6 +99,192 @@ defer f.Close()
 <sup>1</sup> Missing whitespace after block
 
 <sup>2</sup> Missing whitespace after block
+
+</td><td valign="top">
+
+</td></tr>
+</tbody></table>
+
+### `after-decl`
+
+Declaration statements (`var`, `const`, `type`) should be followed by a blank
+line. Consecutive declarations are allowed to cuddle — only the last one in a
+run needs the blank line.
+
+<table>
+<thead><tr><th>Bad</th><th>Good</th></tr></thead>
+<tbody>
+<tr><td valign="top">
+
+```go
+var x int // 1
+x = 1
+
+var (
+    a = 1
+    b = 2
+) // 2
+fmt.Println(a, b)
+```
+
+</td><td valign="top">
+
+```go
+var x int
+
+x = 1
+
+var (
+    a = 1
+    b = 2
+)
+
+fmt.Println(a, b)
+
+var a int
+var b int
+
+fmt.Println(a, b)
+```
+
+</td></tr>
+
+<tr><td valign="top">
+
+<sup>1</sup> Missing whitespace after declaration
+
+<sup>2</sup> Missing whitespace after declaration
+
+</td><td valign="top">
+
+</td></tr>
+</tbody></table>
+
+### `after-defer`
+
+`defer` statements should be followed by a blank line. Consecutive `defer`s
+are allowed to cuddle — only the last one in a run needs the blank line.
+
+<table>
+<thead><tr><th>Bad</th><th>Good</th></tr></thead>
+<tbody>
+<tr><td valign="top">
+
+```go
+f, err := os.Open("x")
+if err != nil {
+    return err
+}
+defer f.Close() // 1
+data := read(f)
+```
+
+</td><td valign="top">
+
+```go
+f, err := os.Open("x")
+if err != nil {
+    return err
+}
+defer f.Close()
+
+data := read(f)
+
+defer a()
+defer b()
+
+doWork()
+```
+
+</td></tr>
+
+<tr><td valign="top">
+
+<sup>1</sup> Missing whitespace after defer
+
+</td><td valign="top">
+
+</td></tr>
+</tbody></table>
+
+### `after-expr`
+
+Expression statements (e.g. function calls used for their side effects) should
+be followed by a blank line. Consecutive expression statements are allowed to
+cuddle — only the last one in a run needs the blank line.
+
+<table>
+<thead><tr><th>Bad</th><th>Good</th></tr></thead>
+<tbody>
+<tr><td valign="top">
+
+```go
+fmt.Println("hello") // 1
+x := 5
+
+fmt.Println(x)
+```
+
+</td><td valign="top">
+
+```go
+fmt.Println("hello")
+
+x := 5
+
+fmt.Println(x)
+
+log.Info("a")
+log.Info("b")
+
+doWork()
+```
+
+</td></tr>
+
+<tr><td valign="top">
+
+<sup>1</sup> Missing whitespace after expression
+
+</td><td valign="top">
+
+</td></tr>
+</tbody></table>
+
+### `after-go`
+
+`go` statements should be followed by a blank line. Consecutive `go`
+statements are allowed to cuddle — only the last one in a run needs the blank
+line.
+
+<table>
+<thead><tr><th>Bad</th><th>Good</th></tr></thead>
+<tbody>
+<tr><td valign="top">
+
+```go
+go work() // 1
+fmt.Println("next")
+```
+
+</td><td valign="top">
+
+```go
+go work()
+
+fmt.Println("next")
+
+go a()
+go b()
+
+fmt.Println("next")
+```
+
+</td></tr>
+
+<tr><td valign="top">
+
+<sup>1</sup> Missing whitespace after go
 
 </td><td valign="top">
 

--- a/CHECKS.md
+++ b/CHECKS.md
@@ -219,6 +219,10 @@ Expression statements (e.g. function calls used for their side effects) should
 be followed by a blank line. Consecutive expression statements are allowed to
 cuddle, only the last one in a run needs the blank line.
 
+**Exception:** an expression statement that is immediately followed by a
+`defer` referencing the same variable is exempt (e.g. `mu.Lock()` /
+`defer mu.Unlock()`), since these two statements form a single logical unit.
+
 <table>
 <thead><tr><th>Bad</th><th>Good</th></tr></thead>
 <tbody>

--- a/CHECKS.md
+++ b/CHECKS.md
@@ -108,8 +108,8 @@ defer f.Close()
 ### `after-decl`
 
 Declaration statements (`var`, `const`, `type`) should be followed by a blank
-line. Consecutive declarations are allowed to cuddle — only the last one in a
-run needs the blank line.
+line. Consecutive declarations of the same kind are allowed to cuddle, only the
+last one in a run needs the blank line.
 
 <table>
 <thead><tr><th>Bad</th><th>Good</th></tr></thead>
@@ -163,7 +163,7 @@ fmt.Println(a, b)
 ### `after-defer`
 
 `defer` statements should be followed by a blank line. Consecutive `defer`s
-are allowed to cuddle — only the last one in a run needs the blank line.
+are allowed to cuddle, only the last one in a run needs the blank line.
 
 <table>
 <thead><tr><th>Bad</th><th>Good</th></tr></thead>
@@ -211,7 +211,7 @@ doWork()
 
 Expression statements (e.g. function calls used for their side effects) should
 be followed by a blank line. Consecutive expression statements are allowed to
-cuddle — only the last one in a run needs the blank line.
+cuddle, only the last one in a run needs the blank line.
 
 <table>
 <thead><tr><th>Bad</th><th>Good</th></tr></thead>
@@ -254,7 +254,7 @@ doWork()
 ### `after-go`
 
 `go` statements should be followed by a blank line. Consecutive `go`
-statements are allowed to cuddle — only the last one in a run needs the blank
+statements are allowed to cuddle, only the last one in a run needs the blank
 line.
 
 <table>

--- a/README.md
+++ b/README.md
@@ -66,6 +66,11 @@ For more details and examples, see [CHECKS](CHECKS.md).
 #### Specific `wsl` cases
 
 - ❌ **after-block** - Require empty line after block statements
+- ❌ **after-decl** - Require empty line after declaration (`var`, `const`,
+  `type`) statements
+- ❌ **after-defer** - Require empty line after `defer` statements
+- ❌ **after-expr** - Require empty line after expression statements
+- ❌ **after-go** - Require empty line after `go` statements
 - ✅ **append** - Only allow re-assigning with `append` if the value being
   appended exist on the line above
 - ❌ **assign-exclusive** - Only allow cuddling either new variables or
@@ -172,6 +177,10 @@ linters:
         - trailing-whitespace
       disable:
         - after-block
+        - after-decl
+        - after-defer
+        - after-expr
+        - after-go
         - assign-exclusive
         - assign-expr
 ```

--- a/analyzer_test.go
+++ b/analyzer_test.go
@@ -136,6 +136,14 @@ func TestWithConfig(t *testing.T) {
 			},
 		},
 		{
+			subdir: "after_decl_with_grouping",
+			configFn: func(config *Configuration) {
+				config.Checks = NoChecks()
+				config.Checks.Add(CheckDecl)
+				config.Checks.Add(CheckAfterDecl)
+			},
+		},
+		{
 			subdir: "cuddle_max_statements_2",
 			configFn: func(config *Configuration) {
 				config.CuddleMaxStatements = 2

--- a/analyzer_test.go
+++ b/analyzer_test.go
@@ -126,6 +126,16 @@ func TestWithConfig(t *testing.T) {
 			},
 		},
 		{
+			subdir: "after_stmts",
+			configFn: func(config *Configuration) {
+				config.Checks = NoChecks()
+				config.Checks.Add(CheckAfterDecl)
+				config.Checks.Add(CheckAfterDefer)
+				config.Checks.Add(CheckAfterExpr)
+				config.Checks.Add(CheckAfterGo)
+			},
+		},
+		{
 			subdir: "cuddle_max_statements_2",
 			configFn: func(config *Configuration) {
 				config.CuddleMaxStatements = 2

--- a/config.go
+++ b/config.go
@@ -35,6 +35,19 @@ const (
 
 	// CheckAfterBlock ensures there's a newline after each block.
 	CheckAfterBlock
+	// CheckAfterDecl ensures there's a newline after a declaration statement
+	// (`var`, `const`, `type`) unless the following statement is another
+	// declaration.
+	CheckAfterDecl
+	// CheckAfterDefer ensures there's a newline after a `defer` statement
+	// unless the following statement is another `defer`.
+	CheckAfterDefer
+	// CheckAfterExpr ensures there's a newline after an expression statement
+	// unless the following statement is another expression statement.
+	CheckAfterExpr
+	// CheckAfterGo ensures there's a newline after a `go` statement unless the
+	// following statement is another `go`.
+	CheckAfterGo
 	// CheckAppend only allows assignments of `append` to be cuddled with other
 	// assignments if it's a variable used in the append statement, e.g.
 	//
@@ -99,6 +112,10 @@ func (c CheckType) String() string {
 		"type-switch",
 		//
 		"after-block",
+		"after-decl",
+		"after-defer",
+		"after-expr",
+		"after-go",
 		"append",
 		"assign-exclusive",
 		"assign-expr",
@@ -217,6 +234,10 @@ func AllChecks() CheckSet {
 	c.Add(CheckAssignExclusive)
 	c.Add(CheckAssignExpr)
 	c.Add(CheckAfterBlock)
+	c.Add(CheckAfterDecl)
+	c.Add(CheckAfterDefer)
+	c.Add(CheckAfterExpr)
+	c.Add(CheckAfterGo)
 
 	return c
 }
@@ -270,6 +291,14 @@ func CheckFromString(s string) (CheckType, error) {
 
 	case "after-block":
 		return CheckAfterBlock, nil
+	case "after-decl":
+		return CheckAfterDecl, nil
+	case "after-defer":
+		return CheckAfterDefer, nil
+	case "after-expr":
+		return CheckAfterExpr, nil
+	case "after-go":
+		return CheckAfterGo, nil
 	case "append":
 		return CheckAppend, nil
 	case "assign-exclusive":

--- a/config_test.go
+++ b/config_test.go
@@ -83,7 +83,7 @@ func TestCheckSet(t *testing.T) {
 func TestToAndFromString(t *testing.T) {
 	t.Parallel()
 
-	maxCheckNumber := 24
+	maxCheckNumber := 28
 
 	for n := range maxCheckNumber {
 		check := CheckType(n)

--- a/cursor.go
+++ b/cursor.go
@@ -11,6 +11,12 @@ type Cursor struct {
 	currentIdx int
 	statements []ast.Stmt
 	checkType  CheckType
+	// rbraceLine is the source line of the enclosing block's closing brace.
+	// It is used to avoid false positives when checking for trailing comments:
+	// an inline comment that sits on the same line as the closing brace belongs
+	// to the brace itself, not to the last statement inside the block.
+	// Zero means the enclosing block boundary is unknown (e.g. case clauses).
+	rbraceLine int
 }
 
 // NewCursor creates a new cursor with a given list of statements.
@@ -18,6 +24,17 @@ func NewCursor(statements []ast.Stmt) *Cursor {
 	return &Cursor{
 		currentIdx: -1,
 		statements: statements,
+	}
+}
+
+// NewBlockCursor creates a cursor for the statements of a known block, recording
+// the source line of the block's closing brace so that trailing-comment checks
+// can ignore inline comments that sit on the brace itself.
+func NewBlockCursor(statements []ast.Stmt, rbraceLine int) *Cursor {
+	return &Cursor{
+		currentIdx: -1,
+		statements: statements,
+		rbraceLine: rbraceLine,
 	}
 }
 

--- a/testdata/src/with_config/after_decl_with_grouping/after_decl_with_grouping.go
+++ b/testdata/src/with_config/after_decl_with_grouping/after_decl_with_grouping.go
@@ -44,12 +44,3 @@ func groupedBlockMissing() {
 	) // want `missing whitespace below this line \(after-decl\)`
 	fmt.Println(a, b)
 }
-
-func groupedBlockOK() {
-	var (
-		a = 1
-		b = 2
-	)
-
-	fmt.Println(a, b)
-}

--- a/testdata/src/with_config/after_decl_with_grouping/after_decl_with_grouping.go
+++ b/testdata/src/with_config/after_decl_with_grouping/after_decl_with_grouping.go
@@ -1,0 +1,55 @@
+package testpkg
+
+import "fmt"
+
+func twoVarsMissing() {
+	// want +2 `missing whitespace above this line \(never cuddle decl\)` `missing whitespace below this line \(after-decl\)`
+	var a = 1
+	var b = 2
+	fmt.Println(a, b)
+}
+
+func twoVarsOK() {
+	var (
+		a = 1
+		b = 2
+	)
+
+	fmt.Println(a, b)
+}
+
+func threeVarsMissing() {
+	// want +3 `missing whitespace above this line \(never cuddle decl\)`
+	// want +3 `missing whitespace above this line \(never cuddle decl\)` `missing whitespace below this line \(after-decl\)`
+	var a = 1
+	var b = 2
+	var c = 3
+	fmt.Println(a, b, c)
+}
+
+func threeVarsOK() {
+	var (
+		a = 1
+		b = 2
+		c = 3
+	)
+
+	fmt.Println(a, b, c)
+}
+
+func groupedBlockMissing() {
+	var (
+		a = 1
+		b = 2
+	) // want `missing whitespace below this line \(after-decl\)`
+	fmt.Println(a, b)
+}
+
+func groupedBlockOK() {
+	var (
+		a = 1
+		b = 2
+	)
+
+	fmt.Println(a, b)
+}

--- a/testdata/src/with_config/after_decl_with_grouping/after_decl_with_grouping.go.golden
+++ b/testdata/src/with_config/after_decl_with_grouping/after_decl_with_grouping.go.golden
@@ -1,0 +1,62 @@
+package testpkg
+
+import "fmt"
+
+func twoVarsMissing() {
+	// want +2 `missing whitespace above this line \(never cuddle decl\)` `missing whitespace below this line \(after-decl\)`
+	var (
+		a = 1
+		b = 2
+	)
+
+	fmt.Println(a, b)
+}
+
+func twoVarsOK() {
+	var (
+		a = 1
+		b = 2
+	)
+
+	fmt.Println(a, b)
+}
+
+func threeVarsMissing() {
+	// want +3 `missing whitespace above this line \(never cuddle decl\)`
+	// want +3 `missing whitespace above this line \(never cuddle decl\)` `missing whitespace below this line \(after-decl\)`
+	var (
+		a = 1
+		b = 2
+		c = 3
+	)
+
+	fmt.Println(a, b, c)
+}
+
+func threeVarsOK() {
+	var (
+		a = 1
+		b = 2
+		c = 3
+	)
+
+	fmt.Println(a, b, c)
+}
+
+func groupedBlockMissing() {
+	var (
+		a = 1
+		b = 2
+	) // want `missing whitespace below this line \(after-decl\)`
+
+	fmt.Println(a, b)
+}
+
+func groupedBlockOK() {
+	var (
+		a = 1
+		b = 2
+	)
+
+	fmt.Println(a, b)
+}

--- a/testdata/src/with_config/after_decl_with_grouping/after_decl_with_grouping.go.golden
+++ b/testdata/src/with_config/after_decl_with_grouping/after_decl_with_grouping.go.golden
@@ -51,12 +51,3 @@ func groupedBlockMissing() {
 
 	fmt.Println(a, b)
 }
-
-func groupedBlockOK() {
-	var (
-		a = 1
-		b = 2
-	)
-
-	fmt.Println(a, b)
-}

--- a/testdata/src/with_config/after_stmts/after_stmts.go
+++ b/testdata/src/with_config/after_stmts/after_stmts.go
@@ -209,3 +209,75 @@ func declFollowedByExpr() {
 	var x = 1 // want `missing whitespace below this line \(after-decl\)`
 	fmt.Println(x)
 }
+
+func mixedDeclKindsMissing() {
+	var a = 1 // want `missing whitespace below this line \(after-decl\)`
+	type B struct {
+		B string
+	} // want `missing whitespace below this line \(after-decl\)`
+	fmt.Println(a) // want `missing whitespace below this line \(after-expr\)`
+	_ = B{}
+}
+
+func mixedDeclKindsOK() {
+	var a = 1
+
+	type B struct {
+		B string
+	}
+
+	fmt.Println(a)
+
+	_ = B{}
+}
+
+func consecutiveTypesMissing() {
+	type A struct {
+		A string
+	}
+	type B struct {
+		B string
+	} // want `missing whitespace below this line \(after-decl\)`
+	fmt.Println(A{}, B{})
+}
+
+func consecutiveTypesOK() {
+	type A struct {
+		A string
+	}
+	type B struct {
+		B string
+	}
+
+	fmt.Println(A{}, B{})
+}
+
+func varThenConstMissing() {
+	var a = 1 // want `missing whitespace below this line \(after-decl\)`
+	const b = 2 // want `missing whitespace below this line \(after-decl\)`
+	fmt.Println(a, b)
+}
+
+func varThenConstOK() {
+	var a = 1
+
+	const b = 2
+
+	fmt.Println(a, b)
+}
+
+func constThenVarMissing() {
+	const a = 1 // want `missing whitespace below this line \(after-decl\)`
+	var b = 2 // want `missing whitespace below this line \(after-decl\)`
+	fmt.Println(a, b)
+}
+
+func sameKindCuddlesOK() {
+	var a = 1
+	var b = 2
+
+	const c = 3
+	const d = 4
+
+	fmt.Println(a, b, c, d)
+}

--- a/testdata/src/with_config/after_stmts/after_stmts.go
+++ b/testdata/src/with_config/after_stmts/after_stmts.go
@@ -59,6 +59,17 @@ func deferLastInFunc() {
 	defer fmt.Println("cleanup")
 }
 
+func deferTrailingCommentMissing() {
+	defer fmt.Println("cleanup") // want `missing whitespace below this line \(after-defer\)`
+	// trailing comment
+}
+
+func deferTrailingCommentOK() {
+	defer fmt.Println("cleanup")
+
+	// trailing comment
+}
+
 // --- after-go ---
 
 func simpleGoMissing() {
@@ -98,6 +109,17 @@ func goAnonFuncMissing() {
 		fmt.Println("work")
 	}() // want `missing whitespace below this line \(after-go\)`
 	fmt.Println("next")
+}
+
+func goTrailingCommentMissing() {
+	go fmt.Println("work") // want `missing whitespace below this line \(after-go\)`
+	// trailing comment
+}
+
+func goTrailingCommentOK() {
+	go fmt.Println("work")
+
+	// trailing comment
 }
 
 // --- after-decl ---
@@ -156,6 +178,19 @@ func declAsOnlyStmt() {
 	var _ = 1
 }
 
+func declTrailingCommentMissing() {
+	var x = 1 // want `missing whitespace below this line \(after-decl\)`
+	// trailing comment
+	_ = x
+}
+
+func declTrailingCommentOK() {
+	var x = 1
+
+	// trailing comment
+	_ = x
+}
+
 // --- after-expr ---
 
 func simpleExprMissing() {
@@ -188,6 +223,17 @@ func multipleExprsOK() {
 	x := 5
 
 	fmt.Println(x)
+}
+
+func exprTrailingCommentMissing() {
+	fmt.Println("hello") // want `missing whitespace below this line \(after-expr\)`
+	// trailing comment
+}
+
+func exprTrailingCommentOK() {
+	fmt.Println("hello")
+
+	// trailing comment
 }
 
 // --- combined interactions ---

--- a/testdata/src/with_config/after_stmts/after_stmts.go
+++ b/testdata/src/with_config/after_stmts/after_stmts.go
@@ -3,6 +3,7 @@ package testpkg
 import (
 	"fmt"
 	"os"
+	"sync"
 )
 
 // --- after-defer ---
@@ -203,6 +204,24 @@ func goFollowedByDefer() {
 	defer fmt.Println("cleanup") // want `missing whitespace below this line \(after-defer\)`
 	x := 1
 	_ = x
+}
+
+func exprFollowedByDeferWithIntersection() {
+	var mu sync.Mutex
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	fmt.Println("protected")
+}
+
+func exprFollowedByDeferNoIntersection() {
+	var mu sync.Mutex
+
+	mu.Lock() // want `missing whitespace below this line \(after-expr\)`
+	defer fmt.Println("cleanup")
+
+	fmt.Println("world")
 }
 
 func declFollowedByExpr() {

--- a/testdata/src/with_config/after_stmts/after_stmts.go
+++ b/testdata/src/with_config/after_stmts/after_stmts.go
@@ -1,0 +1,211 @@
+package testpkg
+
+import (
+	"fmt"
+	"os"
+)
+
+// --- after-defer ---
+
+func simpleDeferMissing() {
+	defer fmt.Println("cleanup") // want `missing whitespace below this line \(after-defer\)`
+	x := 5
+
+	fmt.Println(x)
+}
+
+func simpleDeferOK() {
+	defer fmt.Println("cleanup")
+
+	x := 5
+
+	fmt.Println(x)
+}
+
+func multipleDefersMissing() {
+	defer fmt.Println("a")
+	defer fmt.Println("b") // want `missing whitespace below this line \(after-defer\)`
+	x := 5
+
+	fmt.Println(x)
+}
+
+func multipleDefersOK() {
+	defer fmt.Println("a")
+	defer fmt.Println("b")
+
+	x := 5
+
+	fmt.Println(x)
+}
+
+func deferAfterErrCheckMissing() {
+	f, err := os.Open("example.txt")
+	if err != nil {
+		_ = err
+	}
+	defer f.Close() // want `missing whitespace below this line \(after-defer\)`
+	data := []byte("test")
+	_ = f
+	_ = data
+}
+
+func deferLastInFunc() {
+	x := 1
+
+	fmt.Println(x)
+
+	defer fmt.Println("cleanup")
+}
+
+// --- after-go ---
+
+func simpleGoMissing() {
+	go fmt.Println("work") // want `missing whitespace below this line \(after-go\)`
+	x := 5
+
+	fmt.Println(x)
+}
+
+func simpleGoOK() {
+	go fmt.Println("work")
+
+	x := 5
+
+	fmt.Println(x)
+}
+
+func multipleGoMissing() {
+	go fmt.Println("a")
+	go fmt.Println("b") // want `missing whitespace below this line \(after-go\)`
+	x := 5
+
+	fmt.Println(x)
+}
+
+func multipleGoOK() {
+	go fmt.Println("a")
+	go fmt.Println("b")
+
+	x := 5
+
+	fmt.Println(x)
+}
+
+func goAnonFuncMissing() {
+	go func() {
+		fmt.Println("work")
+	}() // want `missing whitespace below this line \(after-go\)`
+	fmt.Println("next")
+}
+
+// --- after-decl ---
+
+func simpleVarMissing() {
+	var x int // want `missing whitespace below this line \(after-decl\)`
+	x = 1
+
+	fmt.Println(x)
+}
+
+func simpleVarOK() {
+	var x int
+
+	x = 1
+
+	fmt.Println(x)
+}
+
+func cuddledVarsMissing() {
+	var a int
+	var b int // want `missing whitespace below this line \(after-decl\)`
+	fmt.Println(a, b)
+}
+
+func cuddledVarsOK() {
+	var a int
+	var b int
+
+	fmt.Println(a, b)
+}
+
+func varBlockMissing() {
+	var (
+		a = 1
+		b = 2
+	) // want `missing whitespace below this line \(after-decl\)`
+	fmt.Println(a, b)
+}
+
+func varBlockOK() {
+	var (
+		a = 1
+		b = 2
+	)
+
+	fmt.Println(a, b)
+}
+
+func constMissing() {
+	const c = 1 // want `missing whitespace below this line \(after-decl\)`
+	fmt.Println(c)
+}
+
+func declAsOnlyStmt() {
+	var _ = 1
+}
+
+// --- after-expr ---
+
+func simpleExprMissing() {
+	fmt.Println("hello") // want `missing whitespace below this line \(after-expr\)`
+	x := 5
+
+	fmt.Println(x)
+}
+
+func simpleExprOK() {
+	fmt.Println("hello")
+
+	x := 5
+
+	fmt.Println(x)
+}
+
+func multipleExprsMissing() {
+	fmt.Println("a")
+	fmt.Println("b") // want `missing whitespace below this line \(after-expr\)`
+	x := 5
+
+	fmt.Println(x)
+}
+
+func multipleExprsOK() {
+	fmt.Println("a")
+	fmt.Println("b")
+
+	x := 5
+
+	fmt.Println(x)
+}
+
+// --- combined interactions ---
+
+func deferFollowedByExpr() {
+	defer fmt.Println("cleanup") // want `missing whitespace below this line \(after-defer\)`
+	fmt.Println("next")          // want `missing whitespace below this line \(after-expr\)`
+	x := 1
+	_ = x
+}
+
+func goFollowedByDefer() {
+	go fmt.Println("work")       // want `missing whitespace below this line \(after-go\)`
+	defer fmt.Println("cleanup") // want `missing whitespace below this line \(after-defer\)`
+	x := 1
+	_ = x
+}
+
+func declFollowedByExpr() {
+	var x = 1 // want `missing whitespace below this line \(after-decl\)`
+	fmt.Println(x)
+}

--- a/testdata/src/with_config/after_stmts/after_stmts.go.golden
+++ b/testdata/src/with_config/after_stmts/after_stmts.go.golden
@@ -226,3 +226,83 @@ func declFollowedByExpr() {
 
 	fmt.Println(x)
 }
+
+func mixedDeclKindsMissing() {
+	var a = 1 // want `missing whitespace below this line \(after-decl\)`
+
+	type B struct {
+		B string
+	} // want `missing whitespace below this line \(after-decl\)`
+
+	fmt.Println(a) // want `missing whitespace below this line \(after-expr\)`
+
+	_ = B{}
+}
+
+func mixedDeclKindsOK() {
+	var a = 1
+
+	type B struct {
+		B string
+	}
+
+	fmt.Println(a)
+
+	_ = B{}
+}
+
+func consecutiveTypesMissing() {
+	type A struct {
+		A string
+	}
+	type B struct {
+		B string
+	} // want `missing whitespace below this line \(after-decl\)`
+
+	fmt.Println(A{}, B{})
+}
+
+func consecutiveTypesOK() {
+	type A struct {
+		A string
+	}
+	type B struct {
+		B string
+	}
+
+	fmt.Println(A{}, B{})
+}
+
+func varThenConstMissing() {
+	var a = 1 // want `missing whitespace below this line \(after-decl\)`
+
+	const b = 2 // want `missing whitespace below this line \(after-decl\)`
+
+	fmt.Println(a, b)
+}
+
+func varThenConstOK() {
+	var a = 1
+
+	const b = 2
+
+	fmt.Println(a, b)
+}
+
+func constThenVarMissing() {
+	const a = 1 // want `missing whitespace below this line \(after-decl\)`
+
+	var b = 2 // want `missing whitespace below this line \(after-decl\)`
+
+	fmt.Println(a, b)
+}
+
+func sameKindCuddlesOK() {
+	var a = 1
+	var b = 2
+
+	const c = 3
+	const d = 4
+
+	fmt.Println(a, b, c, d)
+}

--- a/testdata/src/with_config/after_stmts/after_stmts.go.golden
+++ b/testdata/src/with_config/after_stmts/after_stmts.go.golden
@@ -62,6 +62,18 @@ func deferLastInFunc() {
 	defer fmt.Println("cleanup")
 }
 
+func deferTrailingCommentMissing() {
+	defer fmt.Println("cleanup") // want `missing whitespace below this line \(after-defer\)`
+
+	// trailing comment
+}
+
+func deferTrailingCommentOK() {
+	defer fmt.Println("cleanup")
+
+	// trailing comment
+}
+
 // --- after-go ---
 
 func simpleGoMissing() {
@@ -104,6 +116,18 @@ func goAnonFuncMissing() {
 	}() // want `missing whitespace below this line \(after-go\)`
 
 	fmt.Println("next")
+}
+
+func goTrailingCommentMissing() {
+	go fmt.Println("work") // want `missing whitespace below this line \(after-go\)`
+
+	// trailing comment
+}
+
+func goTrailingCommentOK() {
+	go fmt.Println("work")
+
+	// trailing comment
 }
 
 // --- after-decl ---
@@ -166,6 +190,20 @@ func declAsOnlyStmt() {
 	var _ = 1
 }
 
+func declTrailingCommentMissing() {
+	var x = 1 // want `missing whitespace below this line \(after-decl\)`
+
+	// trailing comment
+	_ = x
+}
+
+func declTrailingCommentOK() {
+	var x = 1
+
+	// trailing comment
+	_ = x
+}
+
 // --- after-expr ---
 
 func simpleExprMissing() {
@@ -200,6 +238,18 @@ func multipleExprsOK() {
 	x := 5
 
 	fmt.Println(x)
+}
+
+func exprTrailingCommentMissing() {
+	fmt.Println("hello") // want `missing whitespace below this line \(after-expr\)`
+
+	// trailing comment
+}
+
+func exprTrailingCommentOK() {
+	fmt.Println("hello")
+
+	// trailing comment
 }
 
 // --- combined interactions ---

--- a/testdata/src/with_config/after_stmts/after_stmts.go.golden
+++ b/testdata/src/with_config/after_stmts/after_stmts.go.golden
@@ -3,6 +3,7 @@ package testpkg
 import (
 	"fmt"
 	"os"
+	"sync"
 )
 
 // --- after-defer ---
@@ -219,6 +220,25 @@ func goFollowedByDefer() {
 
 	x := 1
 	_ = x
+}
+
+func exprFollowedByDeferWithIntersection() {
+	var mu sync.Mutex
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	fmt.Println("protected")
+}
+
+func exprFollowedByDeferNoIntersection() {
+	var mu sync.Mutex
+
+	mu.Lock() // want `missing whitespace below this line \(after-expr\)`
+
+	defer fmt.Println("cleanup")
+
+	fmt.Println("world")
 }
 
 func declFollowedByExpr() {

--- a/testdata/src/with_config/after_stmts/after_stmts.go.golden
+++ b/testdata/src/with_config/after_stmts/after_stmts.go.golden
@@ -1,0 +1,228 @@
+package testpkg
+
+import (
+	"fmt"
+	"os"
+)
+
+// --- after-defer ---
+
+func simpleDeferMissing() {
+	defer fmt.Println("cleanup") // want `missing whitespace below this line \(after-defer\)`
+
+	x := 5
+
+	fmt.Println(x)
+}
+
+func simpleDeferOK() {
+	defer fmt.Println("cleanup")
+
+	x := 5
+
+	fmt.Println(x)
+}
+
+func multipleDefersMissing() {
+	defer fmt.Println("a")
+	defer fmt.Println("b") // want `missing whitespace below this line \(after-defer\)`
+
+	x := 5
+
+	fmt.Println(x)
+}
+
+func multipleDefersOK() {
+	defer fmt.Println("a")
+	defer fmt.Println("b")
+
+	x := 5
+
+	fmt.Println(x)
+}
+
+func deferAfterErrCheckMissing() {
+	f, err := os.Open("example.txt")
+	if err != nil {
+		_ = err
+	}
+	defer f.Close() // want `missing whitespace below this line \(after-defer\)`
+
+	data := []byte("test")
+	_ = f
+	_ = data
+}
+
+func deferLastInFunc() {
+	x := 1
+
+	fmt.Println(x)
+
+	defer fmt.Println("cleanup")
+}
+
+// --- after-go ---
+
+func simpleGoMissing() {
+	go fmt.Println("work") // want `missing whitespace below this line \(after-go\)`
+
+	x := 5
+
+	fmt.Println(x)
+}
+
+func simpleGoOK() {
+	go fmt.Println("work")
+
+	x := 5
+
+	fmt.Println(x)
+}
+
+func multipleGoMissing() {
+	go fmt.Println("a")
+	go fmt.Println("b") // want `missing whitespace below this line \(after-go\)`
+
+	x := 5
+
+	fmt.Println(x)
+}
+
+func multipleGoOK() {
+	go fmt.Println("a")
+	go fmt.Println("b")
+
+	x := 5
+
+	fmt.Println(x)
+}
+
+func goAnonFuncMissing() {
+	go func() {
+		fmt.Println("work")
+	}() // want `missing whitespace below this line \(after-go\)`
+
+	fmt.Println("next")
+}
+
+// --- after-decl ---
+
+func simpleVarMissing() {
+	var x int // want `missing whitespace below this line \(after-decl\)`
+
+	x = 1
+
+	fmt.Println(x)
+}
+
+func simpleVarOK() {
+	var x int
+
+	x = 1
+
+	fmt.Println(x)
+}
+
+func cuddledVarsMissing() {
+	var a int
+	var b int // want `missing whitespace below this line \(after-decl\)`
+
+	fmt.Println(a, b)
+}
+
+func cuddledVarsOK() {
+	var a int
+	var b int
+
+	fmt.Println(a, b)
+}
+
+func varBlockMissing() {
+	var (
+		a = 1
+		b = 2
+	) // want `missing whitespace below this line \(after-decl\)`
+
+	fmt.Println(a, b)
+}
+
+func varBlockOK() {
+	var (
+		a = 1
+		b = 2
+	)
+
+	fmt.Println(a, b)
+}
+
+func constMissing() {
+	const c = 1 // want `missing whitespace below this line \(after-decl\)`
+
+	fmt.Println(c)
+}
+
+func declAsOnlyStmt() {
+	var _ = 1
+}
+
+// --- after-expr ---
+
+func simpleExprMissing() {
+	fmt.Println("hello") // want `missing whitespace below this line \(after-expr\)`
+
+	x := 5
+
+	fmt.Println(x)
+}
+
+func simpleExprOK() {
+	fmt.Println("hello")
+
+	x := 5
+
+	fmt.Println(x)
+}
+
+func multipleExprsMissing() {
+	fmt.Println("a")
+	fmt.Println("b") // want `missing whitespace below this line \(after-expr\)`
+
+	x := 5
+
+	fmt.Println(x)
+}
+
+func multipleExprsOK() {
+	fmt.Println("a")
+	fmt.Println("b")
+
+	x := 5
+
+	fmt.Println(x)
+}
+
+// --- combined interactions ---
+
+func deferFollowedByExpr() {
+	defer fmt.Println("cleanup") // want `missing whitespace below this line \(after-defer\)`
+
+	fmt.Println("next")          // want `missing whitespace below this line \(after-expr\)`
+
+	x := 1
+	_ = x
+}
+
+func goFollowedByDefer() {
+	go fmt.Println("work")       // want `missing whitespace below this line \(after-go\)`
+
+	defer fmt.Println("cleanup") // want `missing whitespace below this line \(after-defer\)`
+
+	x := 1
+	_ = x
+}
+
+func declFollowedByExpr() {
+	var x = 1 // want `missing whitespace below this line \(after-decl\)`
+
+	fmt.Println(x)
+}

--- a/testdata/src/with_config/all_enabled/all_enabled.go
+++ b/testdata/src/with_config/all_enabled/all_enabled.go
@@ -106,5 +106,7 @@ func chainedInteractions() {
 	switch c {
 	case 1:
 		_ = 1
-	}
+	} // want `missing whitespace below this line \(after-block\)`
+	fmt.Println("a") // want `missing whitespace above this line \(invalid statement above expr\)` `missing whitespace below this line \(after-expr\)`
+	return // want `missing whitespace above this line \(too many lines above return\)`
 }

--- a/testdata/src/with_config/all_enabled/all_enabled.go
+++ b/testdata/src/with_config/all_enabled/all_enabled.go
@@ -94,3 +94,17 @@ func nestedBlocksAllNeedNewlines() {
 	} // want `missing whitespace below this line \(after-block\)`
 	_ = 1 // want `missing whitespace above this line \(invalid statement above assign\)`
 }
+
+func chainedInteractions() {
+	// want +2 `missing whitespace above this line \(never cuddle decl\)` `missing whitespace below this line \(after-decl\)`
+	var a = 1
+	var b = 2
+	if a+b > 0 {
+		_ = 1
+	} // want `missing whitespace below this line \(after-block\)`
+	var c = 3 // want `missing whitespace above this line \(never cuddle decl\)` `missing whitespace below this line \(after-decl\)`
+	switch c {
+	case 1:
+		_ = 1
+	}
+}

--- a/testdata/src/with_config/all_enabled/all_enabled.go
+++ b/testdata/src/with_config/all_enabled/all_enabled.go
@@ -90,7 +90,7 @@ func nestedBlocksAllNeedNewlines() {
 		} // want `missing whitespace below this line \(after-block\)`
 		if false { // want `missing whitespace above this line \(invalid statement above if\)`
 			_ = 1
-		} // want `missing whitespace below this line \(after-block\)`
+		}
 	} // want `missing whitespace below this line \(after-block\)`
 	_ = 1 // want `missing whitespace above this line \(invalid statement above assign\)`
 }

--- a/testdata/src/with_config/all_enabled/all_enabled.go.golden
+++ b/testdata/src/with_config/all_enabled/all_enabled.go.golden
@@ -124,5 +124,9 @@ func chainedInteractions() {
 	switch c {
 	case 1:
 		_ = 1
-	}
+	} // want `missing whitespace below this line \(after-block\)`
+
+	fmt.Println("a") // want `missing whitespace above this line \(invalid statement above expr\)` `missing whitespace below this line \(after-expr\)`
+
+	return // want `missing whitespace above this line \(too many lines above return\)`
 }

--- a/testdata/src/with_config/all_enabled/all_enabled.go.golden
+++ b/testdata/src/with_config/all_enabled/all_enabled.go.golden
@@ -101,8 +101,7 @@ func nestedBlocksAllNeedNewlines() {
 
 		if false { // want `missing whitespace above this line \(invalid statement above if\)`
 			_ = 1
-		} // want `missing whitespace below this line \(after-block\)`
-
+		}
 	} // want `missing whitespace below this line \(after-block\)`
 
 	_ = 1 // want `missing whitespace above this line \(invalid statement above assign\)`

--- a/testdata/src/with_config/all_enabled/all_enabled.go.golden
+++ b/testdata/src/with_config/all_enabled/all_enabled.go.golden
@@ -107,3 +107,22 @@ func nestedBlocksAllNeedNewlines() {
 
 	_ = 1 // want `missing whitespace above this line \(invalid statement above assign\)`
 }
+
+func chainedInteractions() {
+	// want +2 `missing whitespace above this line \(never cuddle decl\)` `missing whitespace below this line \(after-decl\)`
+	var (
+		a = 1
+		b = 2
+	)
+
+	if a+b > 0 {
+		_ = 1
+	} // want `missing whitespace below this line \(after-block\)`
+
+	var c = 3 // want `missing whitespace above this line \(never cuddle decl\)` `missing whitespace below this line \(after-decl\)`
+
+	switch c {
+	case 1:
+		_ = 1
+	}
+}

--- a/wsl.go
+++ b/wsl.go
@@ -811,8 +811,18 @@ func (w *WSL) checkAfterExpr(stmt *ast.ExprStmt, cursor *Cursor) {
 		CheckAfterExpr,
 		false,
 		func(nextStmt ast.Stmt, _ ast.Node) bool {
-			_, ok := nextStmt.(*ast.ExprStmt)
-			return ok
+			// Consecutive expressions don't need a blank line between them.
+			if _, ok := nextStmt.(*ast.ExprStmt); ok {
+				return true
+			}
+
+			// Exception: expr followed by a defer that references the same
+			// variable (e.g. mu.Lock() / defer mu.Unlock()).
+			if deferStmt, ok := nextStmt.(*ast.DeferStmt); ok {
+				return w.hasIntersection(stmt, deferStmt)
+			}
+
+			return false
 		},
 	)
 }

--- a/wsl.go
+++ b/wsl.go
@@ -621,8 +621,15 @@ func (w *WSL) checkAfterDecl(stmt *ast.DeclStmt, cursor *Cursor) {
 		CheckAfterDecl,
 		false,
 		func(nextStmt ast.Stmt, _ ast.Node) bool {
-			_, ok := nextStmt.(*ast.DeclStmt)
-			return ok
+			nextDecl, ok := nextStmt.(*ast.DeclStmt)
+			if !ok {
+				return false
+			}
+
+			currGen, currOK := stmt.Decl.(*ast.GenDecl)
+			nextGen, nextOK := nextDecl.Decl.(*ast.GenDecl)
+
+			return currOK && nextOK && currGen.Tok == nextGen.Tok
 		},
 	)
 }

--- a/wsl.go
+++ b/wsl.go
@@ -368,61 +368,112 @@ func (w *WSL) checkNewlineAfterBlock(block *ast.BlockStmt, cursor *Cursor) {
 		return
 	}
 
+	currentStmt := cursor.Stmt()
+
+	w.checkNewlineAfter(
+		block.Rbrace,
+		block,
+		currentStmt,
+		cursor,
+		CheckAfterBlock,
+		true,
+		func(nextStmt ast.Stmt, previousNode ast.Node) bool {
+			// Exception: if err != nil { } followed by defer that references
+			// a variable assigned above the if block.
+			if w.isErrNotNilCheck(currentStmt) != nil {
+				if deferStmt, ok := nextStmt.(*ast.DeferStmt); ok && previousNode != nil {
+					if w.hasIntersection(previousNode, deferStmt) {
+						return true
+					}
+				}
+			}
+
+			return false
+		},
+	)
+}
+
+// checkNewlineAfter verifies that a blank line separates the current statement
+// (bounded by boundary) from whatever content comes next in its enclosing
+// block. `reportPos` is where the diagnostic is attached, `boundary` is the
+// node whose End() defines the line after which a newline is required, and
+// `currentStmt` is the statement owning the check (used to discriminate
+// comments that still belong to it, e.g. comments inside an else block when
+// checking the if-body). When `checkTrailingComment` is true and currentStmt
+// is the last statement in its block, a trailing comment on the following
+// line (inside the enclosing block) also triggers a diagnostic. If
+// `isException` returns true for the next statement and the previous node, no
+// diagnostic is reported.
+func (w *WSL) checkNewlineAfter(
+	reportPos token.Pos,
+	boundary ast.Node,
+	currentStmt ast.Node,
+	cursor *Cursor,
+	check CheckType,
+	checkTrailingComment bool,
+	isException func(nextStmt ast.Stmt, previousNode ast.Node) bool,
+) {
+	if _, ok := w.config.Checks[check]; !ok {
+		return
+	}
+
+	if cursor.Len() == 0 {
+		return
+	}
+
 	defer cursor.Save()()
 
-	// Capture current statement and previous node before moving cursor.
-	currentStmt := cursor.Stmt()
 	previousNode := cursor.PreviousNode()
 
 	if !cursor.Next() {
+		if !checkTrailingComment {
+			return
+		}
+
 		// No more statements after this one so check for comments after.
 		// Skip comments that are inside the current statement (e.g., inside an else block).
-		if cPos := w.commentOnLineAfterNodePos(block); cPos != token.NoPos && cPos >= currentStmt.End() {
+		if cPos := w.commentOnLineAfterNodePos(boundary); cPos != token.NoPos && cPos >= currentStmt.End() {
 			insertPos := w.lineStartOf(cPos)
 			w.addError(
-				block.Rbrace,
+				reportPos,
 				insertPos,
 				insertPos,
 				messageMissingWhitespaceBelow,
-				CheckAfterBlock,
+				check,
 			)
 		}
 
 		return
 	}
 
-	// Exception: if err != nil { } followed by defer that references
-	// a variable assigned above the if block.
-	if w.isErrNotNilCheck(currentStmt) != nil {
-		if deferStmt, ok := cursor.Stmt().(*ast.DeferStmt); ok && previousNode != nil {
-			if w.hasIntersection(previousNode, deferStmt) {
-				return
-			}
-		}
+	nextStmt := cursor.Stmt()
+	if isException != nil && isException(nextStmt, previousNode) {
+		return
 	}
 
-	rBraceLine := w.lineFor(block.Rbrace)
-	nextContentPos := cursor.Stmt().Pos()
+	boundaryLine := w.lineFor(boundary.End())
+	nextContentPos := nextStmt.Pos()
 	nextContentLine := w.lineFor(nextContentPos)
 
-	// Find the first comment between rbrace and the next statement.
+	// Find the first comment between the boundary and the next statement.
 	for _, cg := range w.file.Comments {
-		if cg.End() <= block.Rbrace {
+		if cg.End() <= boundary.End() {
 			continue
 		}
 
-		// Skip comments that are inside the current statement but after this block.
-		// This handles cases like comments inside an else block when checking the if-body.
+		// Skip comments that are inside the current statement but after the
+		// boundary. This handles cases like comments inside an else block when
+		// checking the if-body.
 		if cg.Pos() < currentStmt.End() {
 			continue
 		}
 
-		if w.lineFor(cg.End()) == rBraceLine {
+		if w.lineFor(cg.End()) == boundaryLine {
 			continue
 		}
 
 		commentLine := w.lineFor(cg.Pos())
-		if commentLine > rBraceLine && commentLine < nextContentLine {
+		if commentLine > boundaryLine && commentLine < nextContentLine {
 			nextContentPos = cg.Pos()
 			nextContentLine = commentLine
 		}
@@ -430,14 +481,14 @@ func (w *WSL) checkNewlineAfterBlock(block *ast.BlockStmt, cursor *Cursor) {
 		break
 	}
 
-	if nextContentLine <= rBraceLine+1 {
+	if nextContentLine <= boundaryLine+1 {
 		insertPos := w.lineStartOf(nextContentPos)
 		w.addError(
-			block.Rbrace,
+			reportPos,
 			insertPos,
 			insertPos,
 			messageMissingWhitespaceBelow,
-			CheckAfterBlock,
+			check,
 		)
 	}
 }
@@ -530,6 +581,8 @@ func (w *WSL) checkBranch(stmt *ast.BranchStmt, cursor *Cursor) {
 }
 
 func (w *WSL) checkDeclStmt(stmt *ast.DeclStmt, cursor *Cursor) {
+	defer w.checkAfterDecl(stmt, cursor)
+
 	if _, ok := w.config.Checks[CheckDecl]; !ok {
 		return
 	}
@@ -549,7 +602,24 @@ func (w *WSL) checkDeclStmt(stmt *ast.DeclStmt, cursor *Cursor) {
 	w.addErrorNeverAllow(stmt.Pos(), cursor.checkType)
 }
 
+func (w *WSL) checkAfterDecl(stmt *ast.DeclStmt, cursor *Cursor) {
+	w.checkNewlineAfter(
+		stmt.End(),
+		stmt,
+		stmt,
+		cursor,
+		CheckAfterDecl,
+		false,
+		func(nextStmt ast.Stmt, _ ast.Node) bool {
+			_, ok := nextStmt.(*ast.DeclStmt)
+			return ok
+		},
+	)
+}
+
 func (w *WSL) checkDefer(stmt *ast.DeferStmt, cursor *Cursor) {
+	defer w.checkAfterDefer(stmt, cursor)
+
 	w.maybeCheckExpr(
 		stmt,
 		cursor,
@@ -580,6 +650,21 @@ func (w *WSL) checkDefer(stmt *ast.DeferStmt, cursor *Cursor) {
 			return true, !previousIsDefer
 		},
 		CheckDefer,
+	)
+}
+
+func (w *WSL) checkAfterDefer(stmt *ast.DeferStmt, cursor *Cursor) {
+	w.checkNewlineAfter(
+		stmt.End(),
+		stmt,
+		stmt,
+		cursor,
+		CheckAfterDefer,
+		false,
+		func(nextStmt ast.Stmt, _ ast.Node) bool {
+			_, ok := nextStmt.(*ast.DeferStmt)
+			return ok
+		},
 	)
 }
 
@@ -687,6 +772,8 @@ func (w *WSL) checkError(
 }
 
 func (w *WSL) checkExprStmt(stmt *ast.ExprStmt, cursor *Cursor) {
+	defer w.checkAfterExpr(stmt, cursor)
+
 	w.maybeCheckExpr(
 		stmt,
 		cursor,
@@ -698,11 +785,28 @@ func (w *WSL) checkExprStmt(stmt *ast.ExprStmt, cursor *Cursor) {
 	)
 }
 
+func (w *WSL) checkAfterExpr(stmt *ast.ExprStmt, cursor *Cursor) {
+	w.checkNewlineAfter(
+		stmt.End(),
+		stmt,
+		stmt,
+		cursor,
+		CheckAfterExpr,
+		false,
+		func(nextStmt ast.Stmt, _ ast.Node) bool {
+			_, ok := nextStmt.(*ast.ExprStmt)
+			return ok
+		},
+	)
+}
+
 func (w *WSL) checkFor(stmt *ast.ForStmt, cursor *Cursor) {
 	w.maybeCheckBlock(stmt, stmt.Body, cursor, CheckFor)
 }
 
 func (w *WSL) checkGo(stmt *ast.GoStmt, cursor *Cursor) {
+	defer w.checkAfterGo(stmt, cursor)
+
 	w.maybeCheckExpr(
 		stmt,
 		cursor,
@@ -713,6 +817,21 @@ func (w *WSL) checkGo(stmt *ast.GoStmt, cursor *Cursor) {
 			return true, !ok
 		},
 		CheckGo,
+	)
+}
+
+func (w *WSL) checkAfterGo(stmt *ast.GoStmt, cursor *Cursor) {
+	w.checkNewlineAfter(
+		stmt.End(),
+		stmt,
+		stmt,
+		cursor,
+		CheckAfterGo,
+		false,
+		func(nextStmt ast.Stmt, _ ast.Node) bool {
+			_, ok := nextStmt.(*ast.GoStmt)
+			return ok
+		},
 	)
 }
 

--- a/wsl.go
+++ b/wsl.go
@@ -581,7 +581,17 @@ func (w *WSL) checkBranch(stmt *ast.BranchStmt, cursor *Cursor) {
 }
 
 func (w *WSL) checkDeclStmt(stmt *ast.DeclStmt, cursor *Cursor) {
-	defer w.checkAfterDecl(stmt, cursor)
+	defer func() {
+		// maybeGroupDecl can advance the cursor past consecutive decls, so
+		// use the cursor's current position at defer-time to get the last
+		// decl in the group.
+		lastDecl, ok := cursor.Stmt().(*ast.DeclStmt)
+		if !ok {
+			lastDecl = stmt
+		}
+
+		w.checkAfterDecl(lastDecl, cursor)
+	}()
 
 	if _, ok := w.config.Checks[CheckDecl]; !ok {
 		return

--- a/wsl.go
+++ b/wsl.go
@@ -130,9 +130,15 @@ func (w *WSL) checkStmt(stmt ast.Stmt, cursor *Cursor) {
 	}
 }
 
-func (w *WSL) checkBody(body []ast.Stmt) {
-	cursor := NewCursor(body)
+func (w *WSL) checkBodyBlock(block *ast.BlockStmt) {
+	w.walkBody(NewBlockCursor(block.List, w.lineFor(block.Rbrace)))
+}
 
+func (w *WSL) checkBodyStmts(stmts []ast.Stmt) {
+	w.walkBody(NewCursor(stmts))
+}
+
+func (w *WSL) walkBody(cursor *Cursor) {
 	for cursor.Next() {
 		w.checkStmt(cursor.Stmt(), cursor)
 	}
@@ -355,7 +361,7 @@ func (w *WSL) checkBlock(block *ast.BlockStmt, cursor *Cursor) {
 	w.checkTrailingNewline(block)
 	w.checkNewlineAfterBlock(block, cursor)
 
-	w.checkBody(block.List)
+	w.checkBodyBlock(block)
 }
 
 func (w *WSL) checkNewlineAfterBlock(block *ast.BlockStmt, cursor *Cursor) {
@@ -376,7 +382,6 @@ func (w *WSL) checkNewlineAfterBlock(block *ast.BlockStmt, cursor *Cursor) {
 		currentStmt,
 		cursor,
 		CheckAfterBlock,
-		true,
 		func(nextStmt ast.Stmt, previousNode ast.Node) bool {
 			// Exception: if err != nil { } followed by defer that references
 			// a variable assigned above the if block.
@@ -410,7 +415,6 @@ func (w *WSL) checkNewlineAfter(
 	currentStmt ast.Node,
 	cursor *Cursor,
 	check CheckType,
-	checkTrailingComment bool,
 	isException func(nextStmt ast.Stmt, previousNode ast.Node) bool,
 ) {
 	if _, ok := w.config.Checks[check]; !ok {
@@ -426,21 +430,26 @@ func (w *WSL) checkNewlineAfter(
 	previousNode := cursor.PreviousNode()
 
 	if !cursor.Next() {
-		if !checkTrailingComment {
-			return
-		}
-
 		// No more statements after this one so check for comments after.
 		// Skip comments that are inside the current statement (e.g., inside an else block).
-		if cPos := w.commentOnLineAfterNodePos(boundary); cPos != token.NoPos && cPos >= currentStmt.End() {
-			insertPos := w.lineStartOf(cPos)
-			w.addError(
-				reportPos,
-				insertPos,
-				insertPos,
-				messageMissingWhitespaceBelow,
-				check,
-			)
+		// Also skip comments that appear on the same line as the enclosing block's closing
+		// brace — those are inline comments on the brace itself, not trailing comments
+		// inside the block.
+		if commentPos := w.commentOnLineAfterNodePos(boundary); commentPos != token.NoPos {
+			isAfterStmt := commentPos >= currentStmt.End()
+			isSameLine := w.lineFor(commentPos) == cursor.rbraceLine
+			isUnknownOrNotSameLine := cursor.rbraceLine == 0 || !isSameLine
+
+			if isAfterStmt && isUnknownOrNotSameLine {
+				insertPos := w.lineStartOf(commentPos)
+				w.addError(
+					reportPos,
+					insertPos,
+					insertPos,
+					messageMissingWhitespaceBelow,
+					check,
+				)
+			}
 		}
 
 		return
@@ -500,7 +509,7 @@ func (w *WSL) checkCaseClause(stmt *ast.CaseClause, cursor *Cursor) {
 		w.checkCaseTrailingNewline(stmt.Body, cursor)
 	}
 
-	w.checkBody(stmt.Body)
+	w.checkBodyStmts(stmt.Body)
 }
 
 func (w *WSL) checkCommClause(stmt *ast.CommClause, cursor *Cursor) {
@@ -510,7 +519,7 @@ func (w *WSL) checkCommClause(stmt *ast.CommClause, cursor *Cursor) {
 		w.checkCaseTrailingNewline(stmt.Body, cursor)
 	}
 
-	w.checkBody(stmt.Body)
+	w.checkBodyStmts(stmt.Body)
 }
 
 func (w *WSL) checkAssign(stmt *ast.AssignStmt, cursor *Cursor) {
@@ -619,7 +628,6 @@ func (w *WSL) checkAfterDecl(stmt *ast.DeclStmt, cursor *Cursor) {
 		stmt,
 		cursor,
 		CheckAfterDecl,
-		false,
 		func(nextStmt ast.Stmt, _ ast.Node) bool {
 			nextDecl, ok := nextStmt.(*ast.DeclStmt)
 			if !ok {
@@ -677,7 +685,6 @@ func (w *WSL) checkAfterDefer(stmt *ast.DeferStmt, cursor *Cursor) {
 		stmt,
 		cursor,
 		CheckAfterDefer,
-		false,
 		func(nextStmt ast.Stmt, _ ast.Node) bool {
 			_, ok := nextStmt.(*ast.DeferStmt)
 			return ok
@@ -809,7 +816,6 @@ func (w *WSL) checkAfterExpr(stmt *ast.ExprStmt, cursor *Cursor) {
 		stmt,
 		cursor,
 		CheckAfterExpr,
-		false,
 		func(nextStmt ast.Stmt, _ ast.Node) bool {
 			// Consecutive expressions don't need a blank line between them.
 			if _, ok := nextStmt.(*ast.ExprStmt); ok {
@@ -854,7 +860,6 @@ func (w *WSL) checkAfterGo(stmt *ast.GoStmt, cursor *Cursor) {
 		stmt,
 		cursor,
 		CheckAfterGo,
-		false,
 		func(nextStmt ast.Stmt, _ ast.Node) bool {
 			_, ok := nextStmt.(*ast.GoStmt)
 			return ok


### PR DESCRIPTION
Add new checks to require whitespace _after_ statements
- `after-decl`
- `after-defer`
- `after-expr`
- `after-go`

Require a blank line separating these type of statements from whatever comes after. This extends the only current after check, `after-block`.

Fixes #235 