### PR TITLE
Add `cuddle-group` check

### DIFF
--- a/CHECKS.md
+++ b/CHECKS.md
@@ -13,6 +13,7 @@
   - [`assign-exclusive`](#assign-exclusive)
   - [`assign-expr`](#assign-expr)
   - [`branch`](#branch)
+  - [`cuddle-group`](#cuddle-group)
   - [`decl`](#decl)
   - [`defer`](#defer)
   - [`err`](#err)
@@ -1590,6 +1591,80 @@ if err != nil {
 <tr><td valign="top">
 
 <sup>1</sup> Whitespace between error assignment and error checking
+
+</td><td valign="top">
+
+</td></tr>
+</tbody></table>
+
+[🔝](#table-of-content)
+
+### `cuddle-group`
+
+Changes *where* the `cuddle-max-statements` violation is reported. Without
+this check, exceeding the limit places the diagnostic on the cuddled statement
+that pushes the chain past the limit, splitting the cuddled group. With this
+check enabled, the diagnostic is placed on the trigger statement (`if`, `for`,
+`switch`, etc., `go`, `defer`, `send`), so the fix inserts a blank line above
+the trigger and keeps the cuddled group together.
+
+The cuddled chain still breaks at the first non-sharing statement (existing
+behavior, unaffected by this check).
+
+In practice this is most useful with the default `cuddle-max-statements: 1`
+(two or more sharing cuddled statements move the blank line above the trigger
+instead of between the variables).
+
+<table>
+<thead><tr><th>Bad</th><th>Good</th></tr></thead>
+<tbody>
+<tr><td valign="top">
+
+```go
+// With the default cuddle-max-statements: 1
+a := 1
+b := 2
+if a > b { // 1
+    fmt.Println("ok")
+}
+```
+
+</td><td valign="top">
+
+```go
+// With the default cuddle-max-statements: 1
+a := 1
+b := 2
+
+if a > b {
+    fmt.Println("ok")
+}
+
+// Without cuddle-group, the same input is fixed by splitting between
+// the cuddled variables instead:
+a := 1
+
+b := 2
+if a > b {
+    fmt.Println("ok")
+}
+
+// Mid-chain non-sharing still splits at the break:
+notUsed := 1
+
+b := 2
+if b > 0 {
+    fmt.Println("ok")
+}
+```
+
+</td></tr>
+
+<tr><td valign="top">
+
+<sup>1</sup> Two cuddled statements share a variable with `if`; with
+`cuddle-group` enabled the group stays cuddled and the blank line goes above
+the `if` instead of between the variables
 
 </td><td valign="top">
 

--- a/CHECKS.md
+++ b/CHECKS.md
@@ -1601,19 +1601,14 @@ if err != nil {
 
 ### `cuddle-group`
 
-Changes _where_ the `cuddle-max-statements` violation is reported. Without
-this check, exceeding the limit places the diagnostic on the cuddled statement
-that pushes the chain past the limit, splitting the cuddled group. With this
-check enabled, the diagnostic is placed on the trigger statement (`if`, `for`,
-`switch`, etc., `go`, `defer`, `send`), so the fix inserts a blank line above
-the trigger and keeps the cuddled group together.
+Treats the cuddled chain above a trigger statement (`if`, `for`, `switch`,
+etc., `go`, `defer`, `send`) as a single unit. The chain stays cuddled with
+the trigger only when _every_ cuddled statement shares a variable with the
+trigger _and_ the number of sharing statements is within
+`cuddle-max-statements`.
 
-The cuddled chain still breaks at the first non-sharing statement (existing
-behavior, unaffected by this check).
-
-In practice this is most useful with the default `cuddle-max-statements: 1`
-(two or more sharing cuddled statements move the blank line above the trigger
-instead of between the variables).
+Without this check, the same violations are reported on a cuddled statement
+inside the chain, splitting the group between variables.
 
 <table>
 <thead><tr><th>Bad</th><th>Good</th></tr></thead>
@@ -1625,6 +1620,13 @@ instead of between the variables).
 a := 1
 b := 2
 if a > b { // 1
+    fmt.Println("ok")
+}
+
+// Mid-chain non-sharing
+notUsed := 1
+b := 2
+if b > 0 { // 2
     fmt.Println("ok")
 }
 ```
@@ -1649,10 +1651,11 @@ if a > b {
     fmt.Println("ok")
 }
 
-// Mid-chain non-sharing still splits at the break:
+// Mid-chain non-sharing — group still separated as
+// a unit:
 notUsed := 1
-
 b := 2
+
 if b > 0 {
     fmt.Println("ok")
 }
@@ -1665,6 +1668,10 @@ if b > 0 {
 <sup>1</sup> Two cuddled statements share a variable with `if`; with
 `cuddle-group` enabled the group stays cuddled and the blank line goes above
 the `if` instead of between the variables
+
+<sup>2</sup> Only one cuddled statement shares with `if`, but a non-sharing
+stmt (`notUsed`) is in the chain so `cuddle-group` separates the entire group
+from the `if` rather than splitting between `notUsed` and `b`
 
 </td><td valign="top">
 

--- a/CHECKS.md
+++ b/CHECKS.md
@@ -1601,7 +1601,7 @@ if err != nil {
 
 ### `cuddle-group`
 
-Changes *where* the `cuddle-max-statements` violation is reported. Without
+Changes _where_ the `cuddle-max-statements` violation is reported. Without
 this check, exceeding the limit places the diagnostic on the cuddled statement
 that pushes the chain past the limit, splitting the cuddled group. With this
 check enabled, the diagnostic is placed on the trigger statement (`if`, `for`,
@@ -1640,8 +1640,8 @@ if a > b {
     fmt.Println("ok")
 }
 
-// Without cuddle-group, the same input is fixed by splitting between
-// the cuddled variables instead:
+// Without cuddle-group, the same input is fixed by
+// splitting between the cuddled variables instead:
 a := 1
 
 b := 2

--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ For more details and examples, see [CHECKS](CHECKS.md).
   re-assigning of existing ones
 - ❌ **assign-expr** - Don't allow assignments to be cuddled with expressions,
   e.g. function calls
+- ❌ **cuddle-group** - When `cuddle-max-statements` is exceeded, place the
+  diagnostic on the trigger statement so the cuddled group stays together and
+  is separated from the block by a blank line (instead of splitting between
+  the cuddled variables)
 - ✅ **err** - Error checking must follow immediately after the error variable
   is assigned
 - ✅ **leading-whitespace** - Disallow leading empty lines in blocks
@@ -184,6 +188,7 @@ linters:
         - after-go
         - assign-exclusive
         - assign-expr
+        - cuddle-group
 ```
 
 ## See also

--- a/README.md
+++ b/README.md
@@ -77,10 +77,8 @@ For more details and examples, see [CHECKS](CHECKS.md).
   re-assigning of existing ones
 - ❌ **assign-expr** - Don't allow assignments to be cuddled with expressions,
   e.g. function calls
-- ❌ **cuddle-group** - When `cuddle-max-statements` is exceeded, place the
-  diagnostic on the trigger statement so the cuddled group stays together and
-  is separated from the block by a blank line (instead of splitting between
-  the cuddled variables)
+- ❌ **cuddle-group** - Treat the cuddled chain as a unit; separate the whole
+  group from the block instead of splitting between cuddled variables
 - ✅ **err** - Error checking must follow immediately after the error variable
   is assigned
 - ✅ **leading-whitespace** - Disallow leading empty lines in blocks

--- a/analyzer_test.go
+++ b/analyzer_test.go
@@ -168,6 +168,19 @@ func TestWithConfig(t *testing.T) {
 				config.CuddleMaxStatements = 0
 			},
 		},
+		{
+			subdir: "cuddle_group",
+			configFn: func(config *Configuration) {
+				config.Checks.Add(CheckCuddleGroup)
+			},
+		},
+		{
+			subdir: "cuddle_group_max_2",
+			configFn: func(config *Configuration) {
+				config.Checks.Add(CheckCuddleGroup)
+				config.CuddleMaxStatements = 2
+			},
+		},
 	} {
 		t.Run(tc.subdir, func(t *testing.T) {
 			t.Parallel()

--- a/config.go
+++ b/config.go
@@ -74,6 +74,20 @@ const (
 	// t1.Fn3()
 	// .
 	CheckAssignExpr
+	// CheckCuddleGroup changes how cuddle-max-statements violations are
+	// reported when more than the configured number of cuddled statements
+	// share a variable with the trigger statement (e.g. `if`, `for`,
+	// `switch`). Instead of pointing at the (N+1)th cuddled statement and
+	// splitting the cuddled group, the diagnostic is placed on the trigger
+	// itself so the entire cuddled group stays together and gets separated
+	// from the trigger by a blank line, e.g.
+	//
+	// a := 1
+	// b := 2
+	//
+	// if a > b {}
+	// .
+	CheckCuddleGroup
 	// CheckErr force error checking to follow immediately after an error
 	// variable is assigned, e.g.
 	//
@@ -119,6 +133,7 @@ func (c CheckType) String() string {
 		"append",
 		"assign-exclusive",
 		"assign-expr",
+		"cuddle-group",
 		"err",
 		"leading-whitespace",
 		"trailing-whitespace",
@@ -238,6 +253,7 @@ func AllChecks() CheckSet {
 	c.Add(CheckAfterDefer)
 	c.Add(CheckAfterExpr)
 	c.Add(CheckAfterGo)
+	c.Add(CheckCuddleGroup)
 
 	return c
 }
@@ -307,6 +323,8 @@ func CheckFromString(s string) (CheckType, error) {
 		return CheckAssignExpr, nil
 	case "err":
 		return CheckErr, nil
+	case "cuddle-group":
+		return CheckCuddleGroup, nil
 	case "leading-whitespace":
 		return CheckLeadingWhitespace, nil
 	case "trailing-whitespace":

--- a/config_test.go
+++ b/config_test.go
@@ -83,7 +83,7 @@ func TestCheckSet(t *testing.T) {
 func TestToAndFromString(t *testing.T) {
 	t.Parallel()
 
-	maxCheckNumber := 28
+	maxCheckNumber := 29
 
 	for n := range maxCheckNumber {
 		check := CheckType(n)

--- a/testdata/src/with_config/all_enabled/all_enabled.go
+++ b/testdata/src/with_config/all_enabled/all_enabled.go
@@ -74,8 +74,8 @@ func errCheckAndAfterBlock() {
 
 func multipleOnSameStatement() {
 	a := 1
-	b := 2 // want `missing whitespace above this line \(too many statements above if\)`
-	if a > 0 {
+	b := 2
+	if a > 0 { // want `missing whitespace above this line \(too many statements above if\)`
 		_ = b
 	} // want `missing whitespace below this line \(after-block\)`
 	c := 3 // want `missing whitespace above this line \(invalid statement above assign\)`
@@ -99,7 +99,7 @@ func chainedInteractions() {
 	// want +2 `missing whitespace above this line \(never cuddle decl\)` `missing whitespace below this line \(after-decl\)`
 	var a = 1
 	var b = 2
-	if a+b > 0 {
+	if a+b > 0 { // want `missing whitespace above this line \(too many statements above if\)`
 		_ = 1
 	} // want `missing whitespace below this line \(after-block\)`
 	var c = 3 // want `missing whitespace above this line \(never cuddle decl\)` `missing whitespace below this line \(after-decl\)`

--- a/testdata/src/with_config/all_enabled/all_enabled.go.golden
+++ b/testdata/src/with_config/all_enabled/all_enabled.go.golden
@@ -82,9 +82,9 @@ func errCheckAndAfterBlock() {
 
 func multipleOnSameStatement() {
 	a := 1
+	b := 2
 
-	b := 2 // want `missing whitespace above this line \(too many statements above if\)`
-	if a > 0 {
+	if a > 0 { // want `missing whitespace above this line \(too many statements above if\)`
 		_ = b
 	} // want `missing whitespace below this line \(after-block\)`
 
@@ -114,7 +114,7 @@ func chainedInteractions() {
 		b = 2
 	)
 
-	if a+b > 0 {
+	if a+b > 0 { // want `missing whitespace above this line \(too many statements above if\)`
 		_ = 1
 	} // want `missing whitespace below this line \(after-block\)`
 

--- a/testdata/src/with_config/cuddle_group/cuddle_group.go
+++ b/testdata/src/with_config/cuddle_group/cuddle_group.go
@@ -42,12 +42,12 @@ func ifManyShareSeparate() {
 	}
 }
 
-// Mid-chain non-sharing stmt: split at the break (existing semantics) and the
-// sharing tail keeps cuddling with the trigger.
+// A non-sharing stmt anywhere in the chain separates the whole group from
+// the trigger — the cuddled chain is treated as a unit.
 func ifNonSharingAbove() {
 	notUsed := 1
-	y := 2 // want `missing whitespace above this line \(variable not shared with if\)`
-	if y > 1 {
+	y := 2
+	if y > 1 { // want `missing whitespace above this line \(too many statements above if\)`
 		fmt.Println("ok")
 	}
 

--- a/testdata/src/with_config/cuddle_group/cuddle_group.go
+++ b/testdata/src/with_config/cuddle_group/cuddle_group.go
@@ -1,0 +1,115 @@
+package testpkg
+
+import "fmt"
+
+// One sharing cuddled stmt is allowed (within default max=1).
+func ifSingleSharing() {
+	x := 1
+	if x > 0 {
+		fmt.Println("ok")
+	}
+}
+
+// Two sharing stmts cuddled with the trigger: keep the group together,
+// separate it from the trigger.
+func ifBothShareSeparate() {
+	x := 1
+	y := 2
+	if x > y { // want `missing whitespace above this line \(too many statements above if\)`
+		fmt.Println("ok")
+	}
+}
+
+// Many sharing stmts: same idea — separate the entire group from the trigger.
+func ifManyShareSeparate() {
+	a := 1
+	b := 2
+	c := 3
+	d := 4
+	if a+b+c+d > 0 { // want `missing whitespace above this line \(too many statements above if\)`
+		fmt.Println("ok")
+	}
+}
+
+// Mid-chain non-sharing stmt: split at the break (existing semantics) and the
+// sharing tail keeps cuddling with the trigger.
+func ifNonSharingAbove() {
+	notUsed := 1
+	y := 2 // want `missing whitespace above this line \(variable not shared with if\)`
+	if y > 1 {
+		fmt.Println("ok")
+	}
+
+	_ = notUsed
+}
+
+// Immediately previous stmt does not share at all: existing
+// "no shared variables" rule still fires before cuddle-group is consulted.
+func ifNoSharingAtAll() {
+	x := 1
+	y := 2
+	if true { // want `missing whitespace above this line \(no shared variables above if\)`
+		fmt.Println("ok")
+	}
+
+	_, _ = x, y
+}
+
+// Other triggers behave the same.
+func forBothShareSeparate() {
+	a := 1
+	b := 2
+	for i := a; i < b; i++ { // want `missing whitespace above this line \(too many statements above for\)`
+		fmt.Println(i)
+	}
+}
+
+func switchBothShareSeparate() {
+	a := 1
+	b := 2
+	switch { // want `missing whitespace above this line \(too many statements above switch\)`
+	case a > b:
+		fmt.Println("a")
+	case b > a:
+		fmt.Println("b")
+	}
+}
+
+func goBothShareSeparate() {
+	a := 1
+	b := 2
+	go fmt.Println(a, b) // want `missing whitespace above this line \(too many statements above go\)`
+}
+
+func deferBothShareSeparate() {
+	a := 1
+	b := 2
+	defer fmt.Println(a, b) // want `missing whitespace above this line \(too many statements above defer\)`
+}
+
+// AllowFirstInBlock interaction: the variables count as sharing because they
+// are used in the first block statement.
+func ifAllUsedInFirstBlock() {
+	a := 1
+	b := 2
+	if true { // want `missing whitespace above this line \(too many statements above if\)`
+		fmt.Println(a, b)
+	}
+}
+
+// Real-world: a string of helper booleans built up before an if that uses all
+// of them. With cuddle-group the helpers stay grouped and the blank line goes
+// above the if, instead of being inserted between two related helpers.
+func isBase64url(s string) bool {
+	for _, c := range s {
+		isUpper := c >= 'A' && c <= 'Z'
+		isLower := c >= 'a' && c <= 'z'
+		isDigit := c >= '0' && c <= '9'
+		isSpecial := c == '-' || c == '_'
+		if !isUpper && !isLower && !isDigit && !isSpecial { // want `missing whitespace above this line \(too many statements above if\)`
+			return false
+		}
+	}
+
+	return true
+}

--- a/testdata/src/with_config/cuddle_group/cuddle_group.go
+++ b/testdata/src/with_config/cuddle_group/cuddle_group.go
@@ -10,6 +10,17 @@ func ifSingleSharing() {
 	}
 }
 
+// A pre-existing blank line breaks the cuddled chain, so only `y` is cuddled
+// with the if. That's one sharing stmt — within max=1 — so no diagnostic.
+func ifBlankLineBreaksChain() {
+	x := 1
+
+	y := 2
+	if x > y {
+		fmt.Println("ok")
+	}
+}
+
 // Two sharing stmts cuddled with the trigger: keep the group together,
 // separate it from the trigger.
 func ifBothShareSeparate() {

--- a/testdata/src/with_config/cuddle_group/cuddle_group.go.golden
+++ b/testdata/src/with_config/cuddle_group/cuddle_group.go.golden
@@ -1,0 +1,125 @@
+package testpkg
+
+import "fmt"
+
+// One sharing cuddled stmt is allowed (within default max=1).
+func ifSingleSharing() {
+	x := 1
+	if x > 0 {
+		fmt.Println("ok")
+	}
+}
+
+// Two sharing stmts cuddled with the trigger: keep the group together,
+// separate it from the trigger.
+func ifBothShareSeparate() {
+	x := 1
+	y := 2
+
+	if x > y { // want `missing whitespace above this line \(too many statements above if\)`
+		fmt.Println("ok")
+	}
+}
+
+// Many sharing stmts: same idea — separate the entire group from the trigger.
+func ifManyShareSeparate() {
+	a := 1
+	b := 2
+	c := 3
+	d := 4
+
+	if a+b+c+d > 0 { // want `missing whitespace above this line \(too many statements above if\)`
+		fmt.Println("ok")
+	}
+}
+
+// Mid-chain non-sharing stmt: split at the break (existing semantics) and the
+// sharing tail keeps cuddling with the trigger.
+func ifNonSharingAbove() {
+	notUsed := 1
+
+	y := 2 // want `missing whitespace above this line \(variable not shared with if\)`
+	if y > 1 {
+		fmt.Println("ok")
+	}
+
+	_ = notUsed
+}
+
+// Immediately previous stmt does not share at all: existing
+// "no shared variables" rule still fires before cuddle-group is consulted.
+func ifNoSharingAtAll() {
+	x := 1
+	y := 2
+
+	if true { // want `missing whitespace above this line \(no shared variables above if\)`
+		fmt.Println("ok")
+	}
+
+	_, _ = x, y
+}
+
+// Other triggers behave the same.
+func forBothShareSeparate() {
+	a := 1
+	b := 2
+
+	for i := a; i < b; i++ { // want `missing whitespace above this line \(too many statements above for\)`
+		fmt.Println(i)
+	}
+}
+
+func switchBothShareSeparate() {
+	a := 1
+	b := 2
+
+	switch { // want `missing whitespace above this line \(too many statements above switch\)`
+	case a > b:
+		fmt.Println("a")
+	case b > a:
+		fmt.Println("b")
+	}
+}
+
+func goBothShareSeparate() {
+	a := 1
+	b := 2
+
+	go fmt.Println(a, b) // want `missing whitespace above this line \(too many statements above go\)`
+}
+
+func deferBothShareSeparate() {
+	a := 1
+	b := 2
+
+	defer fmt.Println(a, b) // want `missing whitespace above this line \(too many statements above defer\)`
+}
+
+// AllowFirstInBlock interaction: the variables count as sharing because they
+// are used in the first block statement.
+func ifAllUsedInFirstBlock() {
+	a := 1
+	b := 2
+
+	if true { // want `missing whitespace above this line \(too many statements above if\)`
+		fmt.Println(a, b)
+	}
+}
+
+// Real-world: a string of helper booleans built up before an if that uses all
+// of them. With cuddle-group the helpers stay grouped and the blank line goes
+// above the if, instead of being inserted between two related helpers.
+func isBase64url(s string) bool {
+	for _, c := range s {
+		isUpper := c >= 'A' && c <= 'Z'
+		isLower := c >= 'a' && c <= 'z'
+		isDigit := c >= '0' && c <= '9'
+		isSpecial := c == '-' || c == '_'
+
+		if !isUpper && !isLower && !isDigit && !isSpecial { // want `missing whitespace above this line \(too many statements above if\)`
+			return false
+		}
+	}
+
+	return true
+}

--- a/testdata/src/with_config/cuddle_group/cuddle_group.go.golden
+++ b/testdata/src/with_config/cuddle_group/cuddle_group.go.golden
@@ -10,6 +10,17 @@ func ifSingleSharing() {
 	}
 }
 
+// A pre-existing blank line breaks the cuddled chain, so only `y` is cuddled
+// with the if. That's one sharing stmt — within max=1 — so no diagnostic.
+func ifBlankLineBreaksChain() {
+	x := 1
+
+	y := 2
+	if x > y {
+		fmt.Println("ok")
+	}
+}
+
 // Two sharing stmts cuddled with the trigger: keep the group together,
 // separate it from the trigger.
 func ifBothShareSeparate() {

--- a/testdata/src/with_config/cuddle_group/cuddle_group.go.golden
+++ b/testdata/src/with_config/cuddle_group/cuddle_group.go.golden
@@ -44,13 +44,13 @@ func ifManyShareSeparate() {
 	}
 }
 
-// Mid-chain non-sharing stmt: split at the break (existing semantics) and the
-// sharing tail keeps cuddling with the trigger.
+// A non-sharing stmt anywhere in the chain separates the whole group from
+// the trigger — the cuddled chain is treated as a unit.
 func ifNonSharingAbove() {
 	notUsed := 1
+	y := 2
 
-	y := 2 // want `missing whitespace above this line \(variable not shared with if\)`
-	if y > 1 {
+	if y > 1 { // want `missing whitespace above this line \(too many statements above if\)`
 		fmt.Println("ok")
 	}
 

--- a/testdata/src/with_config/cuddle_group_max_2/cuddle_group_max_2.go
+++ b/testdata/src/with_config/cuddle_group_max_2/cuddle_group_max_2.go
@@ -22,12 +22,13 @@ func ifThreeShareSeparate() {
 	}
 }
 
-// Mid-chain non-sharing still splits at the break.
+// A non-sharing stmt in the chain still separates the whole group from the
+// trigger, regardless of how many sharing stmts are within the limit.
 func ifNonSharingAbove() {
 	notUsed := 1
-	a := 2 // want `missing whitespace above this line \(variable not shared with if\)`
+	a := 2
 	b := 3
-	if a+b > 0 {
+	if a+b > 0 { // want `missing whitespace above this line \(too many statements above if\)`
 		fmt.Println("ok")
 	}
 

--- a/testdata/src/with_config/cuddle_group_max_2/cuddle_group_max_2.go
+++ b/testdata/src/with_config/cuddle_group_max_2/cuddle_group_max_2.go
@@ -1,0 +1,35 @@
+package testpkg
+
+import "fmt"
+
+// Two sharing cuddled stmts is allowed (within max=2).
+func ifTwoShareWithinLimit() {
+	x := 1
+	y := 2
+	if x > y {
+		fmt.Println("ok")
+	}
+}
+
+// Three sharing stmts exceeds the limit: separate the whole group from the
+// trigger (cuddle-group placement instead of splitting between vars).
+func ifThreeShareSeparate() {
+	a := 1
+	b := 2
+	c := 3
+	if a+b+c > 0 { // want `missing whitespace above this line \(too many statements above if\)`
+		fmt.Println("ok")
+	}
+}
+
+// Mid-chain non-sharing still splits at the break.
+func ifNonSharingAbove() {
+	notUsed := 1
+	a := 2 // want `missing whitespace above this line \(variable not shared with if\)`
+	b := 3
+	if a+b > 0 {
+		fmt.Println("ok")
+	}
+
+	_ = notUsed
+}

--- a/testdata/src/with_config/cuddle_group_max_2/cuddle_group_max_2.go.golden
+++ b/testdata/src/with_config/cuddle_group_max_2/cuddle_group_max_2.go.golden
@@ -1,0 +1,37 @@
+package testpkg
+
+import "fmt"
+
+// Two sharing cuddled stmts is allowed (within max=2).
+func ifTwoShareWithinLimit() {
+	x := 1
+	y := 2
+	if x > y {
+		fmt.Println("ok")
+	}
+}
+
+// Three sharing stmts exceeds the limit: separate the whole group from the
+// trigger (cuddle-group placement instead of splitting between vars).
+func ifThreeShareSeparate() {
+	a := 1
+	b := 2
+	c := 3
+
+	if a+b+c > 0 { // want `missing whitespace above this line \(too many statements above if\)`
+		fmt.Println("ok")
+	}
+}
+
+// Mid-chain non-sharing still splits at the break.
+func ifNonSharingAbove() {
+	notUsed := 1
+
+	a := 2 // want `missing whitespace above this line \(variable not shared with if\)`
+	b := 3
+	if a+b > 0 {
+		fmt.Println("ok")
+	}
+
+	_ = notUsed
+}

--- a/testdata/src/with_config/cuddle_group_max_2/cuddle_group_max_2.go.golden
+++ b/testdata/src/with_config/cuddle_group_max_2/cuddle_group_max_2.go.golden
@@ -23,13 +23,14 @@ func ifThreeShareSeparate() {
 	}
 }
 
-// Mid-chain non-sharing still splits at the break.
+// A non-sharing stmt in the chain still separates the whole group from the
+// trigger, regardless of how many sharing stmts are within the limit.
 func ifNonSharingAbove() {
 	notUsed := 1
-
-	a := 2 // want `missing whitespace above this line \(variable not shared with if\)`
+	a := 2
 	b := 3
-	if a+b > 0 {
+
+	if a+b > 0 { // want `missing whitespace above this line \(too many statements above if\)`
 		fmt.Println("ok")
 	}
 

--- a/wsl.go
+++ b/wsl.go
@@ -210,23 +210,10 @@ func (w *WSL) checkCuddlingMaxAllowed(
 	}
 
 	if _, ok := w.config.Checks[CheckCuddleGroup]; ok {
-		// Walk the entire cuddled chain so we can tell apart a chain that
-		// broke at a non-sharing statement (split at the break) from one
-		// that simply has too many sharing statements (separate the whole
-		// group from the trigger).
+		// Treat the cuddled chain as a unit: any non-sharing stmt or too
+		// many sharing stmts separates the whole group from the trigger.
 		sharedCount, stoppedAtNonIntersection := w.countValidCuddledStatements(targetIdents, cursor, math.MaxInt)
-		if stoppedAtNonIntersection {
-			errorNode := cursor.NthPrevious(sharedCount)
-			if errorNode == nil {
-				return
-			}
-
-			w.addErrorVariableNotShared(errorNode.Pos(), cursor.checkType)
-
-			return
-		}
-
-		if sharedCount > w.config.CuddleMaxStatements {
+		if stoppedAtNonIntersection || sharedCount > w.config.CuddleMaxStatements {
 			w.addErrorTooManyStatements(cursor.Stmt().Pos(), cursor.checkType)
 		}
 

--- a/wsl.go
+++ b/wsl.go
@@ -209,10 +209,7 @@ func (w *WSL) checkCuddlingMaxAllowed(
 		return
 	}
 
-	limit := w.config.CuddleMaxStatements
-	_, cuddleGroup := w.config.Checks[CheckCuddleGroup]
-
-	if cuddleGroup {
+	if _, ok := w.config.Checks[CheckCuddleGroup]; ok {
 		// Walk the entire cuddled chain so we can tell apart a chain that
 		// broke at a non-sharing statement (split at the break) from one
 		// that simply has too many sharing statements (separate the whole
@@ -229,14 +226,14 @@ func (w *WSL) checkCuddlingMaxAllowed(
 			return
 		}
 
-		if sharedCount > limit {
+		if sharedCount > w.config.CuddleMaxStatements {
 			w.addErrorTooManyStatements(cursor.Stmt().Pos(), cursor.checkType)
 		}
 
 		return
 	}
 
-	allowedCount, stoppedAtNonIntersection := w.countValidCuddledStatements(targetIdents, cursor, limit)
+	allowedCount, stoppedAtNonIntersection := w.countValidCuddledStatements(targetIdents, cursor, w.config.CuddleMaxStatements)
 	if numStmtsAbove <= allowedCount {
 		return
 	}

--- a/wsl.go
+++ b/wsl.go
@@ -7,6 +7,7 @@ import (
 	"go/format"
 	"go/token"
 	"go/types"
+	"math"
 	"slices"
 
 	"golang.org/x/tools/go/analysis"
@@ -208,7 +209,34 @@ func (w *WSL) checkCuddlingMaxAllowed(
 		return
 	}
 
-	allowedCount, stoppedAtNonIntersection := w.countValidCuddledStatements(targetIdents, cursor, w.config.CuddleMaxStatements)
+	limit := w.config.CuddleMaxStatements
+	_, cuddleGroup := w.config.Checks[CheckCuddleGroup]
+
+	if cuddleGroup {
+		// Walk the entire cuddled chain so we can tell apart a chain that
+		// broke at a non-sharing statement (split at the break) from one
+		// that simply has too many sharing statements (separate the whole
+		// group from the trigger).
+		sharedCount, stoppedAtNonIntersection := w.countValidCuddledStatements(targetIdents, cursor, math.MaxInt)
+		if stoppedAtNonIntersection {
+			errorNode := cursor.NthPrevious(sharedCount)
+			if errorNode == nil {
+				return
+			}
+
+			w.addErrorVariableNotShared(errorNode.Pos(), cursor.checkType)
+
+			return
+		}
+
+		if sharedCount > limit {
+			w.addErrorTooManyStatements(cursor.Stmt().Pos(), cursor.checkType)
+		}
+
+		return
+	}
+
+	allowedCount, stoppedAtNonIntersection := w.countValidCuddledStatements(targetIdents, cursor, limit)
 	if numStmtsAbove <= allowedCount {
 		return
 	}


### PR DESCRIPTION
If more than `cuddle-max-statements` statements are detected, this check
will add a blank line between them instead of splitting the group.