### PR TITLE
Treat `go` cuddling same as `defer`

### DIFF
--- a/testdata/src/default_config/go/go.go
+++ b/testdata/src/default_config/go/go.go
@@ -1,12 +1,20 @@
 package testpkg
 
-import "fmt"
+import (
+	"fmt"
+	"sync"
+)
 
 func NewT() func() {
 	return func() {}
 }
 
 func Fn(_ int) {}
+
+type Worker struct{}
+
+func (Worker) SetLimit(int) {}
+func (Worker) Run()         {}
 
 func Go() {
 	fooFunc := func() {}
@@ -70,4 +78,33 @@ func GoFuncLit() {
 	}()
 
 	_ = notShared
+}
+
+func GoExprStmt() {
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+	}()
+
+	wg.Wait()
+}
+
+func GoExprStmtDirectCall() {
+	t := Worker{}
+
+	t.SetLimit(1)
+	go t.Run()
+}
+
+func GoExprStmtNoShared() {
+	var wg sync.WaitGroup
+
+	fmt.Println("unrelated")
+	go func() { // want `missing whitespace above this line \(no shared variables above go\)`
+		defer wg.Done()
+	}()
+
+	wg.Wait()
 }

--- a/testdata/src/default_config/go/go.go.golden
+++ b/testdata/src/default_config/go/go.go.golden
@@ -1,13 +1,21 @@
 
 package testpkg
 
-import "fmt"
+import (
+	"fmt"
+	"sync"
+)
 
 func NewT() func() {
 	return func() {}
 }
 
 func Fn(_ int) {}
+
+type Worker struct{}
+
+func (Worker) SetLimit(int) {}
+func (Worker) Run()         {}
 
 func Go() {
 	fooFunc := func() {}
@@ -77,4 +85,34 @@ func GoFuncLit() {
 	}()
 
 	_ = notShared
+}
+
+func GoExprStmt() {
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+	}()
+
+	wg.Wait()
+}
+
+func GoExprStmtDirectCall() {
+	t := Worker{}
+
+	t.SetLimit(1)
+	go t.Run()
+}
+
+func GoExprStmtNoShared() {
+	var wg sync.WaitGroup
+
+	fmt.Println("unrelated")
+
+	go func() { // want `missing whitespace above this line \(no shared variables above go\)`
+		defer wg.Done()
+	}()
+
+	wg.Wait()
 }

--- a/wsl.go
+++ b/wsl.go
@@ -190,10 +190,12 @@ func (w *WSL) checkCuddlingMaxAllowed(
 	}
 
 	_, currIsDefer := stmt.(*ast.DeferStmt)
+	_, currIsGo := stmt.(*ast.GoStmt)
+	currRelaxesPrevType := currIsDefer || currIsGo
 
-	// We're cuddled but not with an assign, declare or defer statement which is
-	// never allowed.
-	if !isAssignDeclOrIncDec(previousNode) && !currIsDefer {
+	// We're cuddled but not with an assign, declare, increment/decrement and
+	// we're not a statement with relaxed check.
+	if !isAssignDeclOrIncDec(previousNode) && !currRelaxesPrevType {
 		w.addErrorInvalidTypeCuddle(cursor.Stmt().Pos(), cursor.checkType)
 		return
 	}
@@ -215,7 +217,7 @@ func (w *WSL) checkCuddlingMaxAllowed(
 		sharedCount, stoppedAtNonIntersection := w.countValidCuddledStatements(
 			targetIdents,
 			cursor,
-			currIsDefer,
+			currRelaxesPrevType,
 			math.MaxInt,
 		)
 		if stoppedAtNonIntersection || sharedCount > w.config.CuddleMaxStatements {
@@ -228,7 +230,7 @@ func (w *WSL) checkCuddlingMaxAllowed(
 	allowedCount, stoppedAtNonIntersection := w.countValidCuddledStatements(
 		targetIdents,
 		cursor,
-		currIsDefer,
+		currRelaxesPrevType,
 		w.config.CuddleMaxStatements,
 	)
 	if numStmtsAbove <= allowedCount {
@@ -277,9 +279,8 @@ func (w *WSL) cuddleTargetIdents(
 // limit is reached. Returns the count and whether the walk stopped because a
 // non-intersecting statement was found (as opposed to the limit).
 //
-// When allowAnyStmtType is true, the trigger statement is a `defer` and any
-// statement type is accepted as a cuddled neighbor (mirroring the relaxed type
-// rule applied at the immediate-previous check).
+// When allowAnyStmtType is true any statement type is accepted as a cuddled
+// neighbor.
 func (w *WSL) countValidCuddledStatements(
 	targetIdents []*ast.Ident,
 	cursor *Cursor,


### PR DESCRIPTION
Add test case with example of idiomatic code, e.g.

```go
func start(t *Worker, limit int) {
    t.SetLimit(limit)
    go t.Run()
}
```