### PR TITLE
Ensure `CheckErr` takes precedence over all other cuddling rules

### DIFF
--- a/testdata/src/with_config/cuddle_group/cuddle_group.go
+++ b/testdata/src/with_config/cuddle_group/cuddle_group.go
@@ -1,6 +1,37 @@
 package testpkg
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+)
+
+func errPairKeepsPairCuddled() {
+	err := errors.New("x")
+	if err != nil {
+		panic(err)
+	}
+}
+
+func errPairWithExtraAboveFiresAboveErr() {
+	a := 1
+	err := errors.New("x") // want `missing whitespace above this line \(too many statements above if\)`
+	if err != nil {
+		panic(err)
+	}
+
+	_ = a
+}
+
+func errPairUncuddledWithExtraGroup() {
+	a := 1
+	err := errors.New("x") // want +1 `unnecessary whitespace \(err\)`
+
+	if err != nil {
+		panic(err)
+	}
+
+	_ = a
+}
 
 // One sharing cuddled stmt is allowed (within default max=1).
 func ifSingleSharing() {

--- a/testdata/src/with_config/cuddle_group/cuddle_group.go.golden
+++ b/testdata/src/with_config/cuddle_group/cuddle_group.go.golden
@@ -1,6 +1,38 @@
 package testpkg
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+)
+
+func errPairKeepsPairCuddled() {
+	err := errors.New("x")
+	if err != nil {
+		panic(err)
+	}
+}
+
+func errPairWithExtraAboveFiresAboveErr() {
+	a := 1
+
+	err := errors.New("x") // want `missing whitespace above this line \(too many statements above if\)`
+	if err != nil {
+		panic(err)
+	}
+
+	_ = a
+}
+
+func errPairUncuddledWithExtraGroup() {
+	a := 1
+
+	err := errors.New("x") // want +1 `unnecessary whitespace \(err\)`
+	if err != nil {
+		panic(err)
+	}
+
+	_ = a
+}
 
 // One sharing cuddled stmt is allowed (within default max=1).
 func ifSingleSharing() {

--- a/testdata/src/with_config/cuddle_group_max_2/cuddle_group_max_2.go
+++ b/testdata/src/with_config/cuddle_group_max_2/cuddle_group_max_2.go
@@ -1,6 +1,37 @@
 package testpkg
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+)
+
+func errPairOverridesGroupMax2() {
+	err := errors.New("x")
+	if err != nil {
+		panic(err)
+	}
+}
+
+func errPairOverridesGroupMax2WithExtra() {
+	a := 1
+	err := errors.New("x") // want `missing whitespace above this line \(too many statements above if\)`
+	if err != nil {
+		panic(err)
+	}
+
+	_ = a
+}
+
+func errPairUncuddledWithExtraGroupMax2() {
+	a := 1
+	err := errors.New("x") // want +1 `unnecessary whitespace \(err\)`
+
+	if err != nil {
+		panic(err)
+	}
+
+	_ = a
+}
 
 // Two sharing cuddled stmts is allowed (within max=2).
 func ifTwoShareWithinLimit() {

--- a/testdata/src/with_config/cuddle_group_max_2/cuddle_group_max_2.go.golden
+++ b/testdata/src/with_config/cuddle_group_max_2/cuddle_group_max_2.go.golden
@@ -1,6 +1,38 @@
 package testpkg
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+)
+
+func errPairOverridesGroupMax2() {
+	err := errors.New("x")
+	if err != nil {
+		panic(err)
+	}
+}
+
+func errPairOverridesGroupMax2WithExtra() {
+	a := 1
+
+	err := errors.New("x") // want `missing whitespace above this line \(too many statements above if\)`
+	if err != nil {
+		panic(err)
+	}
+
+	_ = a
+}
+
+func errPairUncuddledWithExtraGroupMax2() {
+	a := 1
+
+	err := errors.New("x") // want +1 `unnecessary whitespace \(err\)`
+	if err != nil {
+		panic(err)
+	}
+
+	_ = a
+}
 
 // Two sharing cuddled stmts is allowed (within max=2).
 func ifTwoShareWithinLimit() {

--- a/testdata/src/with_config/cuddle_max_statements_2/cuddle_max_statements_2.go
+++ b/testdata/src/with_config/cuddle_max_statements_2/cuddle_max_statements_2.go
@@ -1,10 +1,39 @@
 package testpkg
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
 )
+
+func errPairOverridesMax2() {
+	err := errors.New("x")
+	if err != nil {
+		panic(err)
+	}
+}
+
+func errPairOverridesMax2WithExtra() {
+	a := 1
+	err := errors.New("x") // want `missing whitespace above this line \(too many statements above if\)`
+	if err != nil {
+		panic(err)
+	}
+
+	_ = a
+}
+
+func errPairUncuddledWithExtraMax2() {
+	a := 1
+	err := errors.New("x") // want +1 `unnecessary whitespace \(err\)`
+
+	if err != nil {
+		panic(err)
+	}
+
+	_ = a
+}
 
 func ifBothUsed() {
 	a := 1

--- a/testdata/src/with_config/cuddle_max_statements_2/cuddle_max_statements_2.go.golden
+++ b/testdata/src/with_config/cuddle_max_statements_2/cuddle_max_statements_2.go.golden
@@ -1,10 +1,40 @@
 package testpkg
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
 )
+
+func errPairOverridesMax2() {
+	err := errors.New("x")
+	if err != nil {
+		panic(err)
+	}
+}
+
+func errPairOverridesMax2WithExtra() {
+	a := 1
+
+	err := errors.New("x") // want `missing whitespace above this line \(too many statements above if\)`
+	if err != nil {
+		panic(err)
+	}
+
+	_ = a
+}
+
+func errPairUncuddledWithExtraMax2() {
+	a := 1
+
+	err := errors.New("x") // want +1 `unnecessary whitespace \(err\)`
+	if err != nil {
+		panic(err)
+	}
+
+	_ = a
+}
 
 func ifBothUsed() {
 	a := 1

--- a/testdata/src/with_config/cuddle_max_statements_unlimited/cuddle_max_statements_unlimited.go
+++ b/testdata/src/with_config/cuddle_max_statements_unlimited/cuddle_max_statements_unlimited.go
@@ -1,6 +1,37 @@
 package testpkg
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+)
+
+func errPairOverridesUnlimited() {
+	err := errors.New("x")
+	if err != nil {
+		panic(err)
+	}
+}
+
+func errPairOverridesUnlimitedWithExtra() {
+	a := 1
+	err := errors.New("x") // want `missing whitespace above this line \(too many statements above if\)`
+	if err != nil {
+		panic(err)
+	}
+
+	_ = a
+}
+
+func errPairUncuddledWithExtraUnlimited() {
+	a := 1
+	err := errors.New("x") // want +1 `unnecessary whitespace \(err\)`
+
+	if err != nil {
+		panic(err)
+	}
+
+	_ = a
+}
 
 func ifManyAllUsed() {
 	a := 1

--- a/testdata/src/with_config/cuddle_max_statements_unlimited/cuddle_max_statements_unlimited.go.golden
+++ b/testdata/src/with_config/cuddle_max_statements_unlimited/cuddle_max_statements_unlimited.go.golden
@@ -1,6 +1,38 @@
 package testpkg
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+)
+
+func errPairOverridesUnlimited() {
+	err := errors.New("x")
+	if err != nil {
+		panic(err)
+	}
+}
+
+func errPairOverridesUnlimitedWithExtra() {
+	a := 1
+
+	err := errors.New("x") // want `missing whitespace above this line \(too many statements above if\)`
+	if err != nil {
+		panic(err)
+	}
+
+	_ = a
+}
+
+func errPairUncuddledWithExtraUnlimited() {
+	a := 1
+
+	err := errors.New("x") // want +1 `unnecessary whitespace \(err\)`
+	if err != nil {
+		panic(err)
+	}
+
+	_ = a
+}
 
 func ifManyAllUsed() {
 	a := 1

--- a/testdata/src/with_config/cuddle_max_statements_zero/cuddle_max_statements_zero.go
+++ b/testdata/src/with_config/cuddle_max_statements_zero/cuddle_max_statements_zero.go
@@ -1,6 +1,37 @@
 package testpkg
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+)
+
+func errPairOverridesMaxZero() {
+	err := errors.New("x")
+	if err != nil {
+		panic(err)
+	}
+}
+
+func errPairOverridesMaxZeroWithExtra() {
+	a := 1
+	err := errors.New("x") // want `missing whitespace above this line \(too many statements above if\)`
+	if err != nil {
+		panic(err)
+	}
+
+	_ = a
+}
+
+func errPairUncuddledWithExtraMaxZero() {
+	a := 1
+	err := errors.New("x") // want +1 `unnecessary whitespace \(err\)`
+
+	if err != nil {
+		panic(err)
+	}
+
+	_ = a
+}
 
 // With cuddle-max-statements: 0 nothing may be cuddled above the trigger,
 // even when the variable is used by it.

--- a/testdata/src/with_config/cuddle_max_statements_zero/cuddle_max_statements_zero.go.golden
+++ b/testdata/src/with_config/cuddle_max_statements_zero/cuddle_max_statements_zero.go.golden
@@ -1,6 +1,38 @@
 package testpkg
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+)
+
+func errPairOverridesMaxZero() {
+	err := errors.New("x")
+	if err != nil {
+		panic(err)
+	}
+}
+
+func errPairOverridesMaxZeroWithExtra() {
+	a := 1
+
+	err := errors.New("x") // want `missing whitespace above this line \(too many statements above if\)`
+	if err != nil {
+		panic(err)
+	}
+
+	_ = a
+}
+
+func errPairUncuddledWithExtraMaxZero() {
+	a := 1
+
+	err := errors.New("x") // want +1 `unnecessary whitespace \(err\)`
+	if err != nil {
+		panic(err)
+	}
+
+	_ = a
+}
 
 // With cuddle-max-statements: 0 nothing may be cuddled above the trigger,
 // even when the variable is used by it.

--- a/wsl.go
+++ b/wsl.go
@@ -211,6 +211,23 @@ func (w *WSL) checkCuddlingMaxAllowed(
 		return
 	}
 
+	// CheckErr always have precedence, allowing any permutation of max allowed
+	// cuddled statements and CheckCuddleGroup to be configured but still
+	// respect the requirement to use the idiomatic err checking and never
+	// insert a newline between the err and if.
+	_, errEnabled := w.config.Checks[CheckErr]
+	errIdent := w.isErrNotNilCheck(stmt)
+
+	if errEnabled && errIdent != nil && identsIntersect([]*ast.Ident{errIdent}, previousIdents) {
+		if numStmtsAbove > 1 {
+			if errorNode := cursor.NthPrevious(1); errorNode != nil {
+				w.addErrorTooManyStatements(errorNode.Pos(), cursor.checkType)
+			}
+		}
+
+		return
+	}
+
 	if _, ok := w.config.Checks[CheckCuddleGroup]; ok {
 		// Treat the cuddled chain as a unit: any non-sharing stmt or too
 		// many sharing stmts separates the whole group from the trigger.


### PR DESCRIPTION
No matter what settings there is for cuddle cuddle max statements or if `CheckCuddleGroup` is enabled, `CheckErr` _always_ takes precedence ensuring that the idiomatic error checking with immediate check happens after an error assignment, e.g.

```go
err := errors.New("X")
if err != nil {
    panic(err)
}
```